### PR TITLE
Fix disabled checked switch style

### DIFF
--- a/sass/components/forms/_switches.scss
+++ b/sass/components/forms/_switches.scss
@@ -16,9 +16,11 @@
   width: 0;
   height: 0;
 
-  &:checked + .lever {
+  &:checked:not([disabled]) {
     background-color: $switch-checked-lever-bg;
+  }
 
+  &:checked + .lever {
     &:before, &:after {
       left: 18px;
     }


### PR DESCRIPTION
## Proposed changes
There's a style problem when a switch disabled but checked, the background color should be disabled color, not enabled color.

[Reference design](https://material.angularjs.org/latest/demo/switch)

## Codepen:
[Problem example](https://codepen.io/smankusors/full/dKBPxg)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/Dogfalo/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Note : This is from https://github.com/Dogfalo/materialize/pull/6021