### PR TITLE
fixed passive scroll listener for sidenav

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -442,3 +442,13 @@ M.throttle = function(func, wait, options) {
     return result;
   };
 };
+
+/* Feature detection */
+var passiveIfSupported = false;
+try {
+    window.addEventListener("test", null, 
+        Object.defineProperty({}, "passive", {
+            get: function() { passiveIfSupported = { passive: false }; }
+        }
+    ));
+} catch(err) {}

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -129,11 +129,11 @@
       this._handleCloseReleaseBound = this._handleCloseRelease.bind(this);
       this._handleCloseTriggerClickBound = this._handleCloseTriggerClick.bind(this);
 
-      this.dragTarget.addEventListener('touchmove', this._handleDragTargetDragBound, { passive: true});
+      this.dragTarget.addEventListener('touchmove', this._handleDragTargetDragBound, passiveIfSupported);
       this.dragTarget.addEventListener('touchend', this._handleDragTargetReleaseBound);
-      this._overlay.addEventListener('touchmove', this._handleCloseDragBound, { passive: true});
+      this._overlay.addEventListener('touchmove', this._handleCloseDragBound, passiveIfSupported);
       this._overlay.addEventListener('touchend', this._handleCloseReleaseBound);
-      this.el.addEventListener('touchmove', this._handleCloseDragBound, { passive: true});
+      this.el.addEventListener('touchmove', this._handleCloseDragBound, passiveIfSupported);
       this.el.addEventListener('touchend', this._handleCloseReleaseBound);
       this.el.addEventListener('click', this._handleCloseTriggerClickBound);
 

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -129,11 +129,11 @@
       this._handleCloseReleaseBound = this._handleCloseRelease.bind(this);
       this._handleCloseTriggerClickBound = this._handleCloseTriggerClick.bind(this);
 
-      this.dragTarget.addEventListener('touchmove', this._handleDragTargetDragBound);
+      this.dragTarget.addEventListener('touchmove', this._handleDragTargetDragBound, { passive: true});
       this.dragTarget.addEventListener('touchend', this._handleDragTargetReleaseBound);
-      this._overlay.addEventListener('touchmove', this._handleCloseDragBound);
+      this._overlay.addEventListener('touchmove', this._handleCloseDragBound, { passive: true});
       this._overlay.addEventListener('touchend', this._handleCloseReleaseBound);
-      this.el.addEventListener('touchmove', this._handleCloseDragBound);
+      this.el.addEventListener('touchmove', this._handleCloseDragBound, { passive: true});
       this.el.addEventListener('touchend', this._handleCloseReleaseBound);
       this.el.addEventListener('click', this._handleCloseTriggerClickBound);
 


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Marked the touchmove event handler as 'passive' on [sidenav.js](https://github.com/materializecss/materialize/blob/v1-dev/js/sidenav.js) to make the page more responsive, as per chrome console violation error:

_materialize.min.js?ver=1.0.0:6 [Violation] Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952_

Unfortunately I do not know how to do testing, so have left it unchecked.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
