### PR TITLE
Chips autocomplete should have option to prevent user own input

### DIFF
--- a/jade/page-contents/chips_content.html
+++ b/jade/page-contents/chips_content.html
@@ -152,6 +152,12 @@
               <td>Set autocomplete options.</td>
             </tr>
             <tr>
+              <td>autocompleteOnly</td>
+              <td>Boolean</td>
+              <td>false</td>
+              <td>Toggles abililty to add custom value not in autocomplete list.</td>
+            </tr>
+            <tr>
               <td>limit</td>
               <td>Integer</td>
               <td>Infinity</td>

--- a/js/chips.js
+++ b/js/chips.js
@@ -6,6 +6,7 @@
     placeholder: '',
     secondaryPlaceholder: '',
     autocompleteOptions: {},
+    autocompleteOnly: false,
     limit: Infinity,
     onChipAdd: null,
     onChipSelect: null,
@@ -267,9 +268,11 @@
         }
 
         e.preventDefault();
-        this.addChip({
-          tag: this.$input[0].value
-        });
+        if (!this.hasAutocomplete || (this.hasAutocomplete && !this.options.autocompleteOnly) ) {
+          this.addChip({
+            tag: this.$input[0].value
+          });
+        }
         this.$input[0].value = '';
 
         // delete or left


### PR DESCRIPTION
## Proposed changes
### Chips autocomplete should have option to prevent user own input
* this is an implementation of https://github.com/Dogfalo/materialize/pull/5725
* added boolean option autoCompleteOnly to chips defaults options
* when pressing enter to add a chip, the chip is only added if M.Chips.options.autocompleteOnly==false (or if hasAutcomplete == false)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
