### PR TITLE
Added ability to change tooltip animate opacity.

### DIFF
--- a/jade/_footer.html
+++ b/jade/_footer.html
@@ -28,11 +28,6 @@
               </div>
               <div class="col s12">
                 <div class="patreon-footer-ad">
-                  <a href="https://www.intlum.com/" alt="Intlum" target="_blank" rel="noopener">
-                    <img src="https://i.postimg.cc/qvNNYx32/intlum.png" alt="Intlum">
-                  </a>
-                </div>
-                <div class="patreon-footer-ad">
                   <a href="https://sumatosoft.com/services/ruby-on-rails-development" alt="SUMATOSOFT" target="_blank" rel="noopener">
                     <img src="https://i.postimg.cc/ZYwqSqPb/5130672.png" alt="SUMATOSOFT">
                   </a>

--- a/jade/_footer.html
+++ b/jade/_footer.html
@@ -28,6 +28,11 @@
               </div>
               <div class="col s12">
                 <div class="patreon-footer-ad">
+                  <a href="https://www.intlum.com/" alt="Intlum" target="_blank" rel="noopener">
+                    <img src="https://i.postimg.cc/qvNNYx32/intlum.png" alt="Intlum">
+                  </a>
+                </div>
+                <div class="patreon-footer-ad">
                   <a href="https://sumatosoft.com/services/ruby-on-rails-development" alt="SUMATOSOFT" target="_blank" rel="noopener">
                     <img src="https://i.postimg.cc/ZYwqSqPb/5130672.png" alt="SUMATOSOFT">
                   </a>

--- a/jade/page-contents/tooltips_content.html
+++ b/jade/page-contents/tooltips_content.html
@@ -85,6 +85,12 @@
               <td>Enter transition duration.</td>
             </tr>
             <tr>
+              <td>opacity</td>
+              <td>Number</td>
+              <td>1</td>
+              <td>Opacity of the tooltip.</td>
+            </tr>
+            <tr>
               <td>outDuration</td>
               <td>Number</td>
               <td>250</td>

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -235,7 +235,7 @@
       anim.remove(this.tooltipEl);
       anim({
         targets: this.tooltipEl,
-        opacity: this.options._animateInOpacity || 1,
+        opacity: this.options.opacity || 1,
         translateX: this.xMovement,
         translateY: this.yMovement,
         duration: this.options.inDuration,

--- a/js/tooltip.js
+++ b/js/tooltip.js
@@ -235,7 +235,7 @@
       anim.remove(this.tooltipEl);
       anim({
         targets: this.tooltipEl,
-        opacity: 1,
+        opacity: this.options._animateInOpacity || 1,
         translateX: this.xMovement,
         translateY: this.yMovement,
         duration: this.options.inDuration,


### PR DESCRIPTION
## Proposed changes
Currently using this library for [NiM](https://github.com/june07/NiM) and would like to keep transparent tooltips as seen here:
![NiM Transparent Tooltips](https://user-images.githubusercontent.com/11353590/93024244-d16bc300-f5a9-11ea-916d-08ebe6c23f2a.gif)

This small change adds the ability to change tooltip default opacity using options.  The ultimate result are tooltips that can be transparent.

```
M.Tooltip.init(tooltipElement, {
     _animateInOpacity: 0.7
})
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
