### PR TITLE
revert blur and focus on last chip delete

### DIFF
--- a/js/chips.js
+++ b/js/chips.js
@@ -192,6 +192,8 @@
 
         if (currChips.chipsData.length) {
           currChips.selectChip(selectIndex);
+        } else {
+          currChips.$input[0].focus();
         }
 
         // left arrow key
@@ -231,7 +233,7 @@
      * @param {Event} e
      */
     static _handleChipsBlur(e) {
-      if (!Chips._keydown) {
+      if (!Chips._keydown && document.hidden) {
         let $chips = $(e.target).closest('.chips');
         let currChips = $chips[0].M_Chips;
 
@@ -268,7 +270,7 @@
         }
 
         e.preventDefault();
-        if (!this.hasAutocomplete || (this.hasAutocomplete && !this.options.autocompleteOnly) ) {
+        if (!this.hasAutocomplete || (this.hasAutocomplete && !this.options.autocompleteOnly)) {
           this.addChip({
             tag: this.$input[0].value
           });


### PR DESCRIPTION
## Proposed changes
This is a re-implementation of https://github.com/Dogfalo/materialize/pull/6324.

Original problem statement:
_If you have focused on a chip and then un-focus the entire browser window (not focusing on another element) the \_handleChipsBlur function is executed. This sets null in \_selectedChip but when you return to the window the chip retains its focus. If you try to hit the left, right and delete keys nothing is executed (in delete an exception is thrown)._

* This fix checks for document.hidden and does not unselect the chip if the document is in fact hidden.
  * For notes on compatibility, it looks like IE11 supports document.hidden
    * https://caniuse.com/?search=Page%20Visibility
* Also introduces a minor update that focuses the input element when deleting the last chip.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
