### PR TITLE
Fix Gruntfile.js to prevent erroneous replace

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -548,11 +548,10 @@ module.exports = function(grunt) {
       }
     },
 
-    // Text Replace
+    // Replace text to update the version string
     replace: {
       version: {
-        // Does not edit README.md
-        src: ['bower.json', 'package.json', 'package.js', 'jade/**/*.html'],
+        src: ['bower.json', 'package.js', 'jade/**/*.html'],
         overwrite: true,
         replacements: [
           {
@@ -561,14 +560,13 @@ module.exports = function(grunt) {
           }
         ]
       },
-      readme: {
-        // Changes README.md
-        src: ['README.md'],
+      package_json: {
+        src: ['package.json', ],
         overwrite: true,
         replacements: [
           {
-            from: 'Current Version : v' + grunt.option('oldver'),
-            to: 'Current Version : v' + grunt.option('newver')
+            from: '"version": "' + grunt.option('oldver'),
+            to: '"version": "' + grunt.option('newver')
           }
         ]
       }
@@ -647,7 +645,7 @@ module.exports = function(grunt) {
     'compress:starter_template',
     'compress:parallax_template',
     'replace:version',
-    'replace:readme',
+    'replace:package_json',
     'rename:rename_src',
     'rename:rename_compiled',
     'clean:temp'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -561,7 +561,7 @@ module.exports = function(grunt) {
         ]
       },
       package_json: {
-        src: ['package.json', ],
+        src: ['package.json'],
         overwrite: true,
         replacements: [
           {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

When exec the release script `npx grunt release --oldver=1.0.0 --newver=1.0.1`, grunt accidentally replaced `"grunt-contrib-jade": "^1.0.0"` to `"grunt-contrib-jade": "^1.0.1"`. This behavior can cause a problem, so I fixed it to replace the strings appropriately. Additionally, I removed `replace:readme` task because the description of "Current Version : " has already disappeared from README.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
