### PR TITLE
Revert "Refactored sidenav css to accommodate btns better"

### DIFF
--- a/sass/components/_sidenav.scss
+++ b/sass/components/_sidenav.scss
@@ -38,10 +38,7 @@
     &.active { background-color: rgba(0,0,0,.05); }
   }
 
-  // Style non btn anchors
-  li > a:not(.btn):not(.btn-large):not(.btn-flat):not(.btn-floating) {
-    &:hover { background-color: rgba(0,0,0,.05);}
-
+  li > a {
     color: $sidenav-font-color;
     display: block;
     font-size: $sidenav-font-size;
@@ -49,6 +46,21 @@
     height: $sidenav-item-height;
     line-height: $sidenav-line-height;
     padding: 0 ($sidenav-padding * 2);
+
+    &:hover { background-color: rgba(0,0,0,.05);}
+
+    &.btn, &.btn-large, &.btn-flat, &.btn-floating {
+      margin: 10px 15px;
+    }
+
+    &.btn,
+    &.btn-large,
+    &.btn-floating { color: $button-raised-color; }
+    &.btn-flat { color: $button-flat-color; }
+
+    &.btn:hover,
+    &.btn-large:hover { background-color: lighten($button-raised-background, 5%); }
+    &.btn-floating:hover { background-color: $button-raised-background; }
 
     & > i,
     & > [class^="mdi-"], li > a > [class*="mdi-"],
@@ -62,10 +74,6 @@
     }
   }
 
-  // Style btn anchors
-  li > .btn, li > .btn-large, li > .btn-flat, li > .btn-floating {
-    margin: 10px ($sidenav-padding * 2);
-  }
 
   .divider {
     margin: ($sidenav-padding / 2) 0 0 0;


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR reverts commit bafde665e7b600fc273d0b00596aa52860109206 because it breaks sidenav style.

It is better to understand the motivation for his change, but I don't have any way because this commit doesn't associated to any issues or pull requests, so I decided to simply revert.

## Screenshots (if appropriate) or codepen:

### In https://materializecss.com

<img src="https://user-images.githubusercontent.com/11713748/93710656-5c892200-fb83-11ea-8c66-7778b6fee52d.png" height="320px">

### Current

<img src="https://user-images.githubusercontent.com/11713748/93710834-7119ea00-fb84-11ea-8121-1e5c83f77ea4.png" height="320px">

### After this change

<img src="https://user-images.githubusercontent.com/11713748/93710851-8b53c800-fb84-11ea-9b4d-fc719fc0525a.png" height="320px">


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
