### PR TITLE
Fix modal behavior in Safari

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -20,7 +20,7 @@
   will-change: top, opacity;
 
   @media #{$medium-and-down} {
-   width: 80%;
+    width: 80%;
   }
 
   h1,h2,h3,h4 {
@@ -31,6 +31,7 @@
     padding: 24px;
     overflow-y: hidden;
   }
+
   .modal-close {
     cursor: pointer;
   }
@@ -48,6 +49,7 @@
     }
   }
 }
+
 .modal-overlay {
   position: fixed;
   z-index: 999;

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -29,6 +29,7 @@
 
   .modal-content {
     padding: 24px;
+    overflow-y: hidden;
   }
   .modal-close {
     cursor: pointer;


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

In Safari (both iOS and macOS), if `modal-content` is vertically longer than `modal`, tapping underside the modal area could not close the modal. This PR fixes the problem by specifying overflow-y of `modal-content`.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

### Current

![modal_current](https://user-images.githubusercontent.com/11713748/96083592-68ed6a00-0ef8-11eb-8630-8a8129fac106.gif)

### After this change

![modal_after](https://user-images.githubusercontent.com/11713748/96083604-74409580-0ef8-11eb-981d-92d347b92021.gif)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
