### PR TITLE
enable autocomplete to accept dropdown options

### DIFF
--- a/jade/page-contents/autocomplete_content.html
+++ b/jade/page-contents/autocomplete_content.html
@@ -112,6 +112,12 @@
               <td></td>
               <td>Sort function that defines the order of the list of autocomplete options.</td>
             </tr>
+            <tr>
+              <td>dropdownOptions</td>
+              <td>Object</td>
+              <td>{}</td>
+              <td>Pass options object to select dropdown initialization.</td>
+            </tr>
           </tbody>
         </table>
 

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -5,6 +5,12 @@
     data: {}, // Autocomplete data set
     limit: Infinity, // Limit of results the autocomplete shows
     onAutocomplete: null, // Callback for when autocompleted
+    dropdownOptions: {
+      // Default dropdown options
+      autoFocus: false,
+      closeOnClick: false,
+      coverTrigger: false
+    },
     minLength: 1, // Min characters before autocomplete starts
     sortFunction: function(a, b, inputString) {
       // Sort function for sorting autocomplete results
@@ -152,14 +158,24 @@
       this.$inputField.append(this.container);
       this.el.setAttribute('data-target', this.container.id);
 
-      this.dropdown = M.Dropdown.init(this.el, {
-        autoFocus: false,
-        closeOnClick: false,
-        coverTrigger: false,
-        onItemClick: (itemEl) => {
-          this.selectOption($(itemEl));
+      // Initialize dropdown
+      let dropdownOptions = $.extend(
+        Autocomplete.defaults.dropdownOptions,
+        this.options.dropdownOptions
+      );
+      let userOnItemClick = dropdownOptions.onItemClick;
+
+      // Ensuring the selectOption call when user passes custom onItemClick function to dropdown
+      dropdownOptions.onItemClick = (el) => {
+        this.selectOption($(el));
+
+        // Handle user declared onItemClick if needed
+        if (userOnItemClick && typeof userOnItemClick === 'function') {
+          userOnItemClick.call(this.dropdown, this.el);
         }
-      });
+      };
+
+      this.dropdown = M.Dropdown.init(this.el, dropdownOptions);
 
       // Sketchy removal of dropdown click handler
       this.el.removeEventListener('click', this.dropdown._handleClickBound);


### PR DESCRIPTION
## Proposed changes
* This PR implements https://github.com/Dogfalo/materialize/pull/6602 to enable the autocomplete component to take dropdown options.
  * Note: This does not implement the styling piece of that PR which alters the dropdown style if the container is `document.body`.
* This is also mentioned on the list of PRs to merge and in https://github.com/materializecss/materialize/issues/35.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
