### PR TITLE
Fixed overflowed scroll sidenav on desktop

### DIFF
--- a/sass/components/_sidenav.scss
+++ b/sass/components/_sidenav.scss
@@ -5,9 +5,7 @@
   top: 0;
   margin: 0;
   transform: translateX(-100%);
-  height: 100%;
-  height: calc(100% + 60px);
-  height: -moz-calc(100%); //Temporary Firefox Fix
+  height: 100vh;
   padding-bottom: 60px;
   background-color: $sidenav-bg-color;
   z-index: 999;


### PR DESCRIPTION
## Proposed changes
There's additional 60px because it's problem with mobile devices. Without it, when hiding the address bar, there's some kind of jumpy effect, or rather re-rendering effect that makes UX not really smooth. But this fix comes with another issue, see https://github.com/Dogfalo/materialize/issues/4719. It's fixed on mobile. But in desktop, the scrollbar doesn't look good.

So, instead of using `calc(100% + 60px)`, I think using `100vh` is more appropriate. Here is an [article](https://developers.google.com/web/updates/2016/12/url-bar-resizing) explaining this.

I also deleted a temporary fix (I can't find the documentation about `-moz-calc` thing)

I hope this didn't create another new issue... so tell me if you found one 😉 

## Screenshots (if appropriate) or codepen:
Before : https://codepen.io/smankusors/pen/VwKdwPG

After : https://codepen.io/smankusors/pen/NWRzWjq

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
