### PR TITLE
Nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Run tests
+      run: |
+        npm i
+        npm run test
+
+    - name: Build
+      run: |
+        npm run release
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: dist/


### PR DESCRIPTION
Uses Github Actions (#17) to build on new commits and weekly (in case there are no new commits). Here's an example run: https://github.com/ChildishGiant/materialize/actions/runs/476340135 

The workflow's very simple, it just runs all tests, builds and then uploads the build. 
There's currently no simple way of linking users to the latest build (https://github.com/actions/upload-artifact/issues/52) but it's something for the people waiting on nightly builds (Ping for those in #13). We could link to [nightly.link](https://nightly.link/) in the meantime (https://nightly.link/ChildishGiant/materialize/workflows/nightly/GHA/build) or the equivalent for this repo


## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
