### PR TITLE
Update datepicker & timepicker "container" option to allow being specified the same way

### DIFF
--- a/jade/page-contents/pickers_content.html
+++ b/jade/page-contents/pickers_content.html
@@ -547,7 +547,7 @@ instance.destroy();
                 <td>container</td>
                 <td>Element || String</td>
                 <td>null</td>
-                <td>Specify a DOM element OR selector for a DOM element to render the calendar in, by default it will be placed before the input.</td>
+                <td>Specify a DOM element OR selector for a DOM element to render the time picker in, by default it will be placed before the input.</td>
               </tr>
               <tr>
                 <td>showClearBtn</td>

--- a/jade/page-contents/pickers_content.html
+++ b/jade/page-contents/pickers_content.html
@@ -141,9 +141,9 @@
               </tr>
               <tr>
                 <td>container</td>
-                <td>Element</td>
+                <td>Element || String</td>
                 <td>null</td>
-                <td>Specify a DOM element to render the calendar in, by default it will be placed before the input.</td>
+                <td>Specify a DOM element OR selector for a DOM element to render the calendar in, by default it will be placed before the input.</td>
               </tr>
               <tr>
                 <td>showClearBtn</td>
@@ -545,9 +545,9 @@ instance.destroy();
               </tr>
               <tr>
                 <td>container</td>
-                <td>String</td>
+                <td>Element || String</td>
                 <td>null</td>
-                <td>Specify a selector for a DOM element to render the calendar in, by default it will be placed before the input.</td>
+                <td>Specify a DOM element OR selector for a DOM element to render the calendar in, by default it will be placed before the input.</td>
               </tr>
               <tr>
                 <td>showClearBtn</td>

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -244,6 +244,8 @@
       this.cancelBtn.innerHTML = this.options.i18n.cancel;
 
       if (this.options.container) {
+        const optEl = this.options.container;
+        this.options.container = (optEl instanceof HTMLElement?optEl:document.querySelector(optEl));
         this.$modalEl.appendTo(this.options.container);
       } else {
         this.$modalEl.insertBefore(this.el);

--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -210,7 +210,8 @@
       this.modalEl.id = 'modal-' + this.id;
 
       // Append popover to input by default
-      let containerEl = document.querySelector(this.options.container);
+      const optEl = this.options.container;
+      let containerEl = (optEl instanceof HTMLElement?optEl:document.querySelector(optEl));
       if (this.options.container && !!containerEl) {
         this.$modalEl.appendTo(containerEl);
       } else {


### PR DESCRIPTION
## Proposed changes
The datepicker and timepicker have containers that are specified in different ways (datepicker = element, timepicker = document query selector string). These changes allow both to have the container specified by either an element or a query string for both elements to maintain backward compatability while also harmonizing the entry method.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
