### PR TITLE
Disable outline on focussed dropdown-trigger

### DIFF
--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -81,5 +81,9 @@ body.keyboard-focused {
 }
 
 .dropdown-trigger {
+  &:focus {
+    outline: 0;
+  }
+
   cursor: pointer;
 }


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

As stated in https://github.com/materializecss/materialize/issues/72 the browser puts an ugly outline for an dropdown-trigger which recieves the :focus state. To fix this disable the outline for focussed .dropdown-trigger elements.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
