### PR TITLE
fix(build): deploy docs on github pages from master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,9 +43,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    branches:
-      only:
-        - master
+    on:
+      branch: master
     steps:
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,6 +40,14 @@ jobs:
       - name: test
         run: ls
 
+
+  deploy:
+    runs-on: ubuntu-latest
+    branches:
+      only:
+        - master
+    steps:
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -48,4 +56,3 @@ jobs:
           exclude_assets: node_modules
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-


### PR DESCRIPTION
## Proposed changes
Deploy docs on github pages only from master branch
