### PR TITLE
#6279: fixed aligning of dropdown with coverTrigger=false, when can align bottom

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -419,6 +419,10 @@
       if (!alignments.top) {
         if (alignments.bottom) {
           verticalAlignment = 'bottom';
+
+          if (!this.options.coverTrigger) {
+            idealYPos -= triggerBRect.height;
+          }
         } else {
           this.isScrollable = true;
 


### PR DESCRIPTION
This is another PR for Dogfalo#6279. The initial one is #4.

## Proposed changes
Original PR #4 fixes the alignment issue when there is not enough space **both** on the bottom and top sides.
This PR fixes the dropdown cover when there is not enough space at the bottom side, but still enough space at the top side (so scrolling is not needed).

## Screenshots (if appropriate) or codepen:
_(top and bottow browser panels are part of screenshot, to demonstrate which size is available)_
![image](https://user-images.githubusercontent.com/1275813/112166876-55090b00-8bf0-11eb-987d-dbb717e55d6e.png)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
