### PR TITLE
#93 fixed sharing onOptionClick handler in multiple autocomplete instances

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -161,6 +161,7 @@
 
       // Initialize dropdown
       let dropdownOptions = $.extend(
+        {},
         Autocomplete.defaults.dropdownOptions,
         this.options.dropdownOptions
       );
@@ -305,7 +306,7 @@
       //custom filters may return results where the string does not match any part
       if (start == -1 || end == -1) {
         return [label, '', ''];
-      } 
+      }
       return [label.slice(0, start), label.slice(start, end + 1), label.slice(end + 1)];
     }
 
@@ -389,7 +390,7 @@
         const item = document.createElement('li');
         if (!!entry.data) {
           const img = document.createElement('img');
-          img.classList.add("right", "circle");
+          img.classList.add('right', 'circle');
           img.src = entry.data;
           item.appendChild(img);
         }
@@ -399,11 +400,11 @@
         if (this.options.allowUnsafeHTML) {
           s.innerHTML = parts[0] + '<span class="highlight">' + parts[1] + '</span>' + parts[2];
         } else {
-          s.appendChild(document.createTextNode(parts[0]))
-          if (!!parts[1]){
+          s.appendChild(document.createTextNode(parts[0]));
+          if (!!parts[1]) {
             const highlight = document.createElement('span');
             highlight.textContent = parts[1];
-            highlight.classList.add("highlight");
+            highlight.classList.add('highlight');
             s.appendChild(highlight);
             s.appendChild(document.createTextNode(parts[2]));
           }

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -355,7 +355,9 @@
       if (!!this.options.container) {
         $(this.options.container).append(this.dropdownEl);
       } else if (containerEl) {
-        $(containerEl).append(this.dropdownEl);
+        if (!containerEl.contains(this.dropdownEl)) {
+          $(containerEl).append(this.dropdownEl);
+        }
       } else {
         this.$el.after(this.dropdownEl);
       }

--- a/tests/spec/autocomplete/autocompleteSpec.js
+++ b/tests/spec/autocomplete/autocompleteSpec.js
@@ -97,6 +97,47 @@ describe("Autocomplete Plugin", function () {
         done();
       }, 200);
     });
+
+    it("should select option on click", function(done) {
+      let normal = document.querySelector('#normal-autocomplete');
+
+      M.Autocomplete.init(normal, { data: { 'Value A': null }, minLength: 0 });
+
+      openDropdownAndSelectFirstOption(normal, () => {
+        expect(normal.value).toEqual('Value A', 'Value should equal chosen option.');
+        done();
+      });
+    });
+
+    it("should select proper options on both autocompletes", function(done) {
+      let normal = document.querySelector('#normal-autocomplete');
+      let limited = document.querySelector('#limited-autocomplete');
+      M.Autocomplete.init(normal, { data: { 'Value A': null }, minLength: 0 });
+      M.Autocomplete.init(limited, { data: { 'Value B': null }, minLength: 0 });
+
+      openDropdownAndSelectFirstOption(normal, () => {
+        openDropdownAndSelectFirstOption(limited, () => {
+          expect(normal.value).toEqual('Value A', 'Value should equal chosen option.');
+          expect(limited.value).toEqual('Value B', 'Value should equal chosen option.');
+          done();
+        });
+      });
+    });
   });
+
+  function openDropdownAndSelectFirstOption(autocomplete, onFinish) {
+    click(autocomplete);
+
+    setTimeout(function() {
+      let firstOption = autocomplete.parentNode.querySelector('.autocomplete-content li');
+      click(firstOption);
+
+      setTimeout(function() {
+        onFinish();
+      }, 300);
+
+    }, 200);
+  }
+
 
 });


### PR DESCRIPTION
This is a bugfix for #93 

## Proposed changes
As a part of this PR I make autocomplete options independent between instances

Also there is a fix in `dropdown.js : _moveDropdown`, which avoids adding a component to the same parent twice (it caused tests to fail, since on the second append a child was removed from a parent)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
