### PR TITLE
feat(dropdown): ♿  improve dropdown & autocomplete a11y

### DIFF
--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -269,6 +269,13 @@
             .children('li')
             .eq(this.activeIndex);
           this.$active.addClass('active');
+
+          // Focus selected
+          this.container.children[this.activeIndex].scrollIntoView({
+            behavior: 'smooth',
+            block: 'nearest',
+            inline: 'nearest'
+          });
         }
       }
     }

--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -278,6 +278,9 @@
         } while (newFocusedIndex < this.dropdownEl.children.length && newFocusedIndex >= 0);
 
         if (foundNewIndex) {
+          // Remove active class from old element
+          if (this.focusedIndex >= 0)
+            this.dropdownEl.children[this.focusedIndex].classList.remove('active');
           this.focusedIndex = newFocusedIndex;
           this._focusFocusedItem();
         }
@@ -383,7 +386,12 @@
         this.focusedIndex < this.dropdownEl.children.length &&
         this.options.autoFocus
       ) {
-        this.dropdownEl.children[this.focusedIndex].focus();
+        this.dropdownEl.children[this.focusedIndex].classList.add('active');
+        this.dropdownEl.children[this.focusedIndex].scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'nearest'
+        });
       }
     }
 


### PR DESCRIPTION
Dropdown and autocomplete now smoothly scrolls to elements selected with keyboard (Closes #12)

Here's a before and after:

### [Before](https://codepen.io/ChildishGiant/pen/wvgGzoE)
https://user-images.githubusercontent.com/13716824/112668270-3906a300-8e56-11eb-93e3-cd9e7a1b640c.mp4

### [After](https://codepen.io/ChildishGiant/pen/LYxNRPZ)
https://user-images.githubusercontent.com/13716824/112668352-52a7ea80-8e56-11eb-8446-efa063cf109b.mp4

You can see I made it smooth scroll as the jumping about that was previously used can be a bit jarring.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Debatable since the current implementation was disabled for autocompletes because it didn't work.
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
