### PR TITLE
add copy code button

### DIFF
--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -231,3 +231,19 @@
     });
   }); // end of document ready
 })(jQuery); // end of jQuery name space
+
+// Copy Button
+function copyText() {
+  const copiedText = document.getElementById('copiedText').textContent
+  const textArea = document.createElement('textArea');
+  textArea.textContent = copiedText;
+  document.body.append(textArea);
+  textArea.select();
+  textArea.setSelectionRange(0, 99999)
+  document.execCommand('copy');
+  document.getElementById('copyButton')
+  .insertAdjacentHTML('afterend',
+  `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
+  )
+  // alert("Code copied to clipboard: " + textArea.value);
+  }

--- a/jade/getting_started/getting_started_content.html
+++ b/jade/getting_started/getting_started_content.html
@@ -34,7 +34,9 @@
             <br>
             <h5>CDN</h5>
             <p>You can find all the versions of the CDN at <a href="https://www.jsdelivr.com/package/npm/@materializecss/materialize">jsDelivr</a>.</p>
-            <pre><code class="language-markup">
+            <p><a class="waves-effect waves-light btn" id="copyButton" onclick="copyText()">Copy code <i
+              class="material-icons right">content_copy</i></a></p>
+            <pre><code class="language-markup" id="copiedText">
     &lt;!-- Compiled and minified CSS -->
     &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.0.0/dist/css/materialize.min.css">
 


### PR DESCRIPTION
## Proposed changes
Hello! So glad to see Materialize is still being maintained. I use the framework frequently. I thought it would be much easier to grab the CDN if there was a 'copy code' button.

I saw that the issue was also brought up here - https://github.com/Dogfalo/materialize/issues/6611#issue-731825880

 It took a bit of digging to put together code that works, but I've added it here. I am more familiar with vanilla JS than jQuery so I opted to just add my code at the bottom of the init.js file. I am not sure what would be considered best practice for your codebase, so I'm open to feedback or suggestions. Thoughts: 1) It could of course be implemented for other code snippets across the site. 2) A tooltip or modal might work better than an alert [ edit: I changed this to a span, though some users may want more context? ]. Happy to work on this more :)

Codepen for quick reference: https://codepen.io/christinavoudouris/pen/xxgzjwP

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.