### PR TITLE
[DRAFT] added prototype styling for dark theme support

### DIFF
--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -10,6 +10,7 @@ body {
   line-height: 1.6;
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
+  background-color: var(--surface-color);
 }
 
 p.box {

--- a/sass/components/_buttons.scss
+++ b/sass/components/_buttons.scss
@@ -280,6 +280,7 @@ button.btn-floating {
   &:focus,
   &:hover {
     box-shadow: none;
+    background-color: $button-flat-hover-background-color;
   }
   &:focus {
     background-color: rgba(0, 0, 0, .1);

--- a/sass/components/_dropdown.scss
+++ b/sass/components/_dropdown.scss
@@ -68,7 +68,7 @@
 
 body.keyboard-focused {
   .dropdown-content li:focus {
-    background-color: darken($dropdown-hover-bg-color, 8%);
+    background-color: $dropdown-focus-bg-color;
   }
 }
 

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -114,7 +114,7 @@ a {
 .divider {
   height: 1px;
   overflow: hidden;
-  background-color: color("grey", "lighten-2");
+  background-color: $divider-color;
 }
 
 

--- a/sass/components/_sidenav.scss
+++ b/sass/components/_sidenav.scss
@@ -33,7 +33,7 @@
     float: none;
     line-height: $sidenav-line-height;
 
-    &.active { background-color: rgba(0,0,0,.05); }
+    &.active { background-color: $button-flat-focus-background-color; }
   }
 
   li > a {
@@ -45,7 +45,7 @@
     line-height: $sidenav-line-height;
     padding: 0 ($sidenav-padding * 2);
 
-    &:hover { background-color: rgba(0,0,0,.05);}
+    &:hover { background-color: $button-flat-hover-background-color;}
 
     &.btn, &.btn-large, &.btn-flat, &.btn-floating {
       margin: 10px 15px;
@@ -68,7 +68,7 @@
       line-height: $sidenav-line-height;
       margin: 0 ($sidenav-padding * 2) 0 0;
       width: $sidenav-item-height / 2;
-      color: rgba(0,0,0,.54);
+      color: $sidenav-icon-color;
     }
   }
 
@@ -84,7 +84,7 @@
 
     cursor: initial;
     pointer-events: none;
-    color: rgba(0,0,0,.54);
+    color: $sidenav-subheader-color;
     font-size: $sidenav-font-size;
     font-weight: 500;
     line-height: $sidenav-line-height;

--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -47,17 +47,19 @@
     a {
       &:focus,
       &:focus.active {
-        background-color: transparentize($tabs-underline-color, .8);
+        background-color: $tabs-focus-bg-color;
         outline: none;
       }
 
-      &:hover,
       &.active {
-        background-color: transparent;
-        color: $tabs-text-color;
+        color: $tabs-active-text-color;
       }
 
-      color: rgba($tabs-text-color, .7);
+      &:hover {
+        background-color: $tabs-hover-bg-color;
+      }
+
+      color: $tabs-text-color;
       display: block;
       width: 100%;
       height: 100%;
@@ -70,8 +72,9 @@
 
     &.disabled a,
     &.disabled a:hover {
-      color: rgba($tabs-text-color, .4);
+      color: $tabs-disabled-text-color;
       cursor: default;
+      background-color: transparent;
     }
   }
   .indicator {

--- a/sass/components/_theme_variables.css
+++ b/sass/components/_theme_variables.css
@@ -1,0 +1,41 @@
+:root {
+    --surface-color: #ffffff;
+    --background-color: #ffffff;
+
+    --font-color-main: rgba(0, 0, 0, 0.87);
+    --font-color-medium: rgba(0, 0, 0, 0.56);
+    --font-color-disabled: rgba(0, 0, 0, 0.38);
+
+    --hover-color: rgba(0, 0, 0, 0.04);
+    --focus-color: rgba(0, 0, 0, 0.12);
+    --focus-color-solid: #E0E0E0;
+
+    --background-color-disabled: rgba(0, 0, 0, 0.12);
+    --background-color-level-4dp: rgba(0, 0, 0, 0.09);
+
+    --separator-color: #DDDDDD; /* borders between components */
+
+    --slider-track-color: rgba(0, 0, 0, 0.32);
+    --switch-thumb-off-color: #ffffff;
+}
+
+:root[theme='dark'] {
+    --surface-color: #121212;
+    --background-color: #242424;
+
+    --font-color-main: rgba(255, 255, 255, 0.87);
+    --font-color-medium: rgba(255, 255, 255, 0.60);
+    --font-color-disabled: rgba(255, 255, 255, 0.38);
+
+    --hover-color: rgba(255, 255, 255, 0.04);
+    --focus-color: rgba(255, 255, 255, 0.12);
+    --focus-color-solid: #424242;
+
+    --background-color-disabled: rgba(255, 255, 255, 0.12);
+    --background-color-level-4dp: rgba(255, 255, 255, 0.09);
+
+    --separator-color: #424242; /* borders between components */
+
+    --slider-track-color: rgba(255, 255, 255, 0.32);
+    --switch-thumb-off-color: #bababa;
+}

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -58,7 +58,8 @@
 
 /* Analog Clock Display */
 .timepicker-analog-display {
-  flex: 2.5 auto;
+	flex: 2.5 auto;
+	background-color: $timepicker-clock-bg;
 }
 
 .timepicker-plate {

--- a/sass/components/_variables.scss
+++ b/sass/components/_variables.scss
@@ -43,7 +43,16 @@ $success-color: color("green", "base") !default;
 $error-color: color("red", "base") !default;
 $link-color: color("light-blue", "darken-1") !default;
 
+$bg-color: var(--background-color) !default;
+$bg-hover-color-opaque: var(--hover-color) !default;
+$bg-focus-color-opaque: var(--focus-color) !default;
 
+$secondary-color-when-hovered-solid: lighten($secondary-color, 4%) !default;
+$secondary-color-when-focused-solid: lighten($secondary-color, 12%) !default;
+$secondary-color-hover-opaque: rgba($secondary-color, 0.08) !default;
+$secondary-color-focus-opaque: rgba($secondary-color, 0.24) !default;
+
+$divider-color: var(--separator-color);
 // 2. Badges
 // ==========================================================================
 
@@ -64,8 +73,8 @@ $button-padding: 0 16px !default;
 $button-radius: 2px !default;
 
 // Disabled styles
-$button-disabled-background: #DFDFDF !default;
-$button-disabled-color: #9F9F9F !default;
+$button-disabled-background: var(--background-color-disabled) !default;
+$button-disabled-color: var(--font-color-disabled) !default;
 
 // Raised buttons
 $button-raised-background: $secondary-color !default;
@@ -85,8 +94,10 @@ $button-small-height: $button-height * .9 !default;
 $button-floating-small-size: $button-height * .9 !default;
 
 // Flat buttons
-$button-flat-color: #343434 !default;
-$button-flat-disabled-color: lighten(#999, 10%) !default;
+$button-flat-color: var(--font-color-medium) !default;
+$button-flat-hover-background-color: var(--hover-color) !default;
+$button-flat-focus-background-color: var(--focus-color) !default;
+$button-flat-disabled-color: var(--font-color-disabled) !default;
 
 // Floating buttons
 $button-floating-background: $secondary-color !default;
@@ -146,15 +157,17 @@ $datepicker-selected-outfocus: desaturate(lighten($secondary-color, 35%), 15%) !
 $datepicker-day-focus: transparentize(desaturate($secondary-color, 5%), .75) !default;
 $datepicker-disabled-day-color: rgba(0, 0, 0, .3) !default;
 
-$timepicker-clock-color: rgba(0, 0, 0, .87) !default;
-$timepicker-clock-plate-bg: #eee !default;
+$timepicker-clock-bg: $bg-color !default;
+$timepicker-clock-color: var(--font-color-main) !default;
+$timepicker-clock-plate-bg: var(--background-color-level-4dp) !default;
 
 
 // 9. Dropdown
 // ==========================================================================
 
-$dropdown-bg-color: #fff !default;
-$dropdown-hover-bg-color: #eee !default;
+$dropdown-bg-color: $bg-color !default;
+$dropdown-hover-bg-color: $bg-hover-color-opaque !default;
+$dropdown-focus-bg-color: $bg-focus-color-opaque !default;
 $dropdown-color: $secondary-color !default;
 $dropdown-item-height: 50px !default;
 
@@ -164,7 +177,8 @@ $dropdown-item-height: 50px !default;
 
 // Text Inputs + Textarea
 $input-height: 3rem !default;
-$input-border-color: color("grey", "base") !default;
+$input-border-color: var(--font-color-medium) !default;
+$input-color: var(--font-color-main) !default;
 $input-border: 1px solid $input-border-color !default;
 $input-background: #fff !default;
 $input-error-color: $error-color !default;
@@ -180,7 +194,7 @@ $input-disabled-solid-color: #949494 !default;
 $input-disabled-border: 1px dotted $input-disabled-color !default;
 $input-invalid-border: 1px solid $input-error-color !default;
 $input-icon-size: 2rem;
-$placeholder-text-color: lighten($input-border-color, 20%) !default;
+$placeholder-text-color: var(--font-color-medium) !default;
 
 // Radio Buttons
 $radio-fill-color: $secondary-color !default;
@@ -191,23 +205,29 @@ $radio-border: 2px solid $radio-fill-color !default;
 $range-height: 14px !default;
 $range-width: 14px !default;
 $track-height: 3px !default;
+$range-track-color: var(--slider-track-color) !default;
 
 // Select
 $select-border: 1px solid #f2f2f2 !default;
-$select-background: rgba(255, 255, 255, 0.90) !default;
+$select-background: $bg-color !default;
 $select-focus: 1px solid lighten($secondary-color, 47%) !default;
-$select-option-hover: rgba(0,0,0,.08) !default;
-$select-option-focus: rgba(0,0,0,.08) !default;
-$select-option-selected: rgba(0,0,0,.03) !default;
+$select-option-hover: $bg-hover-color-opaque !default;
+$select-option-focus: $bg-focus-color-opaque !default;
+$select-option-selected: $bg-focus-color-opaque !default;
 $select-padding: 5px !default;
 $select-radius: 2px !default;
-$select-disabled-color: rgba(0,0,0,.3) !default;
+$select-disabled-color: var(--font-color-disabled) !default;
+$select-input-color: var(--font-color-main)  !default;
 
 // Switches
-$switch-bg-color: $secondary-color !default;
-$switch-checked-lever-bg: desaturate(lighten($switch-bg-color, 25%), 25%) !default;
-$switch-unchecked-bg: #F1F1F1 !default;
-$switch-unchecked-lever-bg: rgba(0,0,0,.38) !default;
+$switch-thumb-checked-color: $secondary-color !default;
+$switch-thumb-unchecked-color: var(--switch-thumb-off-color) !default;
+$switch-track-unchecked-bg: var(--slider-track-color) !default;
+$switch-track-checked-bg: rgba($secondary-color, 0.32)  !default;
+$switch-reaction-checked-focus-color: $secondary-color-focus-opaque !default;
+$switch-reaction-unchecked-focus-color: $bg-focus-color-opaque !default;
+$switch-reaction-checked-hover-color: $secondary-color-hover-opaque !default;
+$switch-reaction-unchecked-hover-color: $bg-hover-color-opaque !default;
 $switch-radius: 15px !default;
 
 
@@ -255,8 +275,10 @@ $navbar-brand-font-size: 2.1rem !default;
 
 $sidenav-width: 300px !default;
 $sidenav-font-size: 14px !default;
-$sidenav-font-color: rgba(0,0,0,.87) !default;
-$sidenav-bg-color: #fff !default;
+$sidenav-font-color: var(--font-color-main) !default;
+$sidenav-bg-color: $bg-color !default;
+$sidenav-icon-color: var(--font-color-medium) !default;
+$sidenav-subheader-color: var(--font-color-medium) !default;
 $sidenav-padding: 16px !default;
 $sidenav-item-height: 48px !default;
 $sidenav-line-height: $sidenav-item-height !default;
@@ -279,9 +301,13 @@ $spinner-default-color: $secondary-color !default;
 // 17. Tabs
 // ==========================================================================
 
-$tabs-underline-color: $primary-color-light !default;
-$tabs-text-color: $primary-color !default;
-$tabs-bg-color: #fff !default;
+$tabs-underline-color: $secondary-color !default;
+$tabs-text-color: $button-flat-color !default;
+$tabs-active-text-color: $secondary-color !default;
+$tabs-disabled-text-color: $button-disabled-color !default;
+$tabs-bg-color: var(--background-color) !default;
+$tabs-hover-bg-color: var(--hover-color) !default;
+$tabs-focus-bg-color: var(--focus-color) !default;
 
 
 // 18. Tables
@@ -304,7 +330,7 @@ $toast-action-color: #eeff41;
 // ==========================================================================
 
 $font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif !default;
-$off-black: rgba(0, 0, 0, 0.87) !default;
+$off-black: var(--font-color-main) !default;
 // Header Styles
 $h1-fontsize: 4.2rem !default;
 $h2-fontsize: 3.56rem !default;

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -25,6 +25,7 @@ textarea.materialize-textarea {
 
   // General Styles
   background-color: transparent;
+  color: $input-color;
   border: none;
   border-bottom: $input-border;
   border-radius: 0;

--- a/sass/components/forms/_range.scss
+++ b/sass/components/forms/_range.scss
@@ -63,7 +63,7 @@ input[type=range] + .thumb {
 // Shared
 @mixin range-track {
   height: $track-height;
-  background: #c2c0c2;
+  background: $range-track-color;
   border: none;
 }
 
@@ -100,8 +100,6 @@ input[type=range]::-webkit-slider-thumb {
 
 // FireFox
 input[type=range] {
-  /* fix for FF unable to apply focus style bug  */
-  border: 1px solid white;
 
   /*required for proper track sizing in FF*/
 }

--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -84,7 +84,7 @@ select {
     bottom: 0;
     margin: auto 0;
     z-index: 0;
-    fill: rgba(0,0,0,.87);
+    fill: $select-input-color;
   }
 
   & + label {

--- a/sass/components/forms/_select.scss
+++ b/sass/components/forms/_select.scss
@@ -74,6 +74,7 @@ select {
     display: block;
     user-select:none;
     z-index: 1;
+    color: $select-input-color;
   }
 
   .caret {
@@ -143,11 +144,11 @@ body.keyboard-focused {
 
 .select-dropdown.dropdown-content {
   li {
-    &:hover {
+    &:hover:not(.disabled) {
       background-color: $select-option-hover;
     }
 
-    &.selected {
+    &.selected:not(.disabled) {
       background-color: $select-option-selected;
     }
   }

--- a/sass/components/forms/_switches.scss
+++ b/sass/components/forms/_switches.scss
@@ -16,8 +16,8 @@
   width: 0;
   height: 0;
 
-  &:checked:not([disabled]) {
-    background-color: $switch-checked-lever-bg;
+  &:checked + .lever {
+    background-color: $switch-track-checked-bg;
   }
 
   &:checked + .lever {
@@ -26,7 +26,7 @@
     }
 
     &:after {
-      background-color: $switch-bg-color;
+      background-color: $switch-thumb-checked-color;
     }
   }
 }
@@ -37,7 +37,7 @@
   position: relative;
   width: 36px;
   height: 14px;
-  background-color: $switch-unchecked-lever-bg;
+  background-color: $switch-track-unchecked-bg;
   border-radius: $switch-radius;
   margin-right: 10px;
   transition: background 0.3s ease;
@@ -56,36 +56,40 @@
     transition: left 0.3s ease, background .3s ease, box-shadow 0.1s ease, transform .1s ease;
   }
 
-  &:before {
-    background-color: transparentize($switch-bg-color, .85);
-  }
-
   &:after {
-    background-color: $switch-unchecked-bg;
+    background-color: $switch-thumb-unchecked-color;
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
+}
+
+input[type=checkbox]:not(:disabled) ~ .lever:active:before,
+input[type=checkbox]:not(:disabled).tabbed:focus ~ .lever::before,
+input[type=checkbox]:not(:disabled) ~ .lever:hover::before {
+  transform: scale(2.4);
+}
+
+input[type=checkbox]:checked:not(:disabled) ~ .lever:hover::before {
+  background-color: $switch-reaction-checked-hover-color;
 }
 
 // Switch active style
 input[type=checkbox]:checked:not(:disabled) ~ .lever:active::before,
 input[type=checkbox]:checked:not(:disabled).tabbed:focus ~ .lever::before {
-  transform: scale(2.4);
-  background-color: transparentize($switch-bg-color, .85);
+  background-color: $switch-reaction-checked-focus-color;
+}
+
+input[type=checkbox]:not(:disabled) ~ .lever:hover::before {
+  background-color: $switch-reaction-unchecked-hover-color;
 }
 
 input[type=checkbox]:not(:disabled) ~ .lever:active:before,
 input[type=checkbox]:not(:disabled).tabbed:focus ~ .lever::before {
-  transform: scale(2.4);
-  background-color: rgba(0,0,0,.08);
+  background-color: $switch-reaction-unchecked-focus-color;
 }
 
 // Disabled Styles
 .switch input[type=checkbox][disabled] + .lever {
   cursor: default;
-  background-color: rgba(0,0,0,.12);
+  opacity: 0.5;
 }
 
-.switch label input[type=checkbox][disabled] + .lever:after,
-.switch label input[type=checkbox][disabled]:checked + .lever:after {
-  background-color: $input-disabled-solid-color;
-}

--- a/sass/materialize.scss
+++ b/sass/materialize.scss
@@ -39,3 +39,4 @@
 @import "components/pulse";
 @import "components/datepicker";
 @import "components/timepicker";
+@import "components/_theme_variables.css";


### PR DESCRIPTION
## Proposed changes
Here is a prototype of basic dark theme support. Theme variables are defined in sass/components/_theme_variables.css

By default `:root` variables are applied. If a `theme = dark` attribute added to `document`, then dark variables are picked up. In this way it would be possible to have even more than 2 themes per application if needed

I decided not to use css variables in scss files directly, but put them in scss variables (e.g. `$bg-color: var(--background-color) !default;`), this would be less breaking for users, who work with custom scss variables in their projects

I also adjusted tab/switch styling to better reflect material UI guidelines (and to use fewer variables).

If we would like to continue with this approach, I would kindly ask to merge #85 first, because there are quite some intersecting changes

Here is the testbed, which I used: https://materialize-testbed.s3-us-west-2.amazonaws.com/dark-theme/index.html#!
You can find theme switch in the right upper corner 


The switch theme code looks like this:
```
      if (darkTheme) {
        document.documentElement.setAttribute('theme', 'dark');
      } else {
        document.documentElement.removeAttribute('theme');
      }
```

## Screenshots (if appropriate) or codepen:
![image](https://user-images.githubusercontent.com/1275813/116001336-4a2d0600-a5f4-11eb-9c9d-7b04fb02d7a0.png)
![image](https://user-images.githubusercontent.com/1275813/116001367-6fba0f80-a5f4-11eb-8482-2d02c34c5ab3.png)


## Types of changes
It might be a breaking change for users, who override sass variables.
Also, it would change a look of some components (to better match material UI guidelines)

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
