### PR TITLE
Autocomplete off for docs

### DIFF
--- a/pug/_navbar.pug
+++ b/pug/_navbar.pug
@@ -23,7 +23,7 @@ header
           a(href='http://archives.materializecss.com/0.100.2/') 0.100.2
     li(class="search")
       div.search-wrapper
-        input(id="search", placeholder="Search")
+        input(id="search", placeholder="Search" autocomplete="off")
         i.material-icons search
         div.search-results
     li.bold(class=(page == "About" ? "active" : ""))


### PR DESCRIPTION
Dependant on #141 (how I've done it)

Currently the browser's default autocomplete can get in the way of our one:
![image](https://user-images.githubusercontent.com/13716824/119203375-ca774780-ba8a-11eb-88a4-c8a2b786a334.png)

I changed one line to stop that (Although it will seem like loads because it's comparing to master, not #141 )
![image](https://user-images.githubusercontent.com/13716824/119203555-335ebf80-ba8b-11eb-95fe-c43ae153c99b.png)
