### PR TITLE
Fix ERR_FILE_NOT_FOUND when running npm test

### DIFF
--- a/tests/spec/cards/cardsFixture.html
+++ b/tests/spec/cards/cardsFixture.html
@@ -2,7 +2,7 @@
   <div class="col s12 m6">
     <div class="card reveal">
     <div class="card-image waves-effect waves-block waves-light">
-      <img class="activator" src="images/office.jpg">
+      <img class="activator" src="docs/images/office.jpg">
     </div>
     <div class="card-content">
       <span class="card-title activator grey-text text-darken-4">Card Title<i class="material-icons right">more_vert</i></span>
@@ -17,7 +17,7 @@
   <div class="col s12 m6">
     <div class="card image">
       <div class="card-image">
-        <img src="http://www.isaachernandez.com/wp-content/uploads/2012/02/Isaac-Hernandez-self-portrait-20701.jpg">
+        <img src="docs/images/sample-1.jpg">
         <span class="card-title">Card Title</span>
       </div>
       <div class="card-content">
@@ -35,7 +35,7 @@
   <div class="col s4">
     <div class="card small">
       <div class="card-image">
-        <img src="images/sample-1.jpg">
+        <img src="docs/images/sample-1.jpg">
         <span class="card-title">Card Title</span>
       </div>
       <div class="card-content">
@@ -50,7 +50,7 @@
   <div class="col s4">
     <div class="card medium">
       <div class="card-image">
-        <img src="images/sample-1.jpg">
+        <img src="docs/images/sample-1.jpg">
         <span class="card-title">Card Title</span>
       </div>
       <div class="card-content">
@@ -65,7 +65,7 @@
   <div class="col s4">
     <div class="card large">
       <div class="card-image">
-        <img src="images/sample-1.jpg">
+        <img src="docs/images/sample-1.jpg">
         <span class="card-title">Card Title</span>
       </div>
       <div class="card-content">

--- a/tests/spec/sidenav/sidenavFixture.html
+++ b/tests/spec/sidenav/sidenavFixture.html
@@ -1,9 +1,9 @@
 <ul id="slide-out" class="sidenav">
   <li><div class="user-view">
     <div class="background">
-      <img src="images/office.jpg">
+      <img src="docs/images/office.jpg">
     </div>
-    <a href="#!user"><img class="circle" src="images/yuna.jpg"></a>
+    <a href="#!user"><img class="circle" src="docs/images/yuna.jpg"></a>
     <a href="#!name"><span class="white-text name">John Doe</span></a>
     <a href="#!email"><span class="white-text email">jdoe@example.com</span></a>
   </div></li>


### PR DESCRIPTION
## Proposed changes
When running `npm test`, there's a warning shown below when testing Card and Sidenav plugin

```
log: Failed to load resource: net::ERR_FILE_NOT_FOUND
log: Failed to load resource: the server responded with a status of 403 (Forbidden)
```

This is happen when we merged #78, where the "images" folder moved to "docs" folder. This PR fixes the img src to the updated one. There's also one image on the card component that become missing (403 forbidden), so I replaced it with [sample-1.jpg](https://github.com/materializecss/materialize/blob/eb04cbfff7b523ee76167af1e2401c3d95762c8c/docs/images/sample-1.jpg).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:


- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/v1-dev/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
