### PR TITLE
open old docs in new window

### DIFF
--- a/pug/_navbar.pug
+++ b/pug/_navbar.pug
@@ -20,7 +20,7 @@ header
         li
           a 1.0.0
         li
-          a(href='http://archives.materializecss.com/0.100.2/') 0.100.2
+          a(href='http://archives.materializecss.com/0.100.2/' target='_blank') 0.100.2
     li(class="search")
       div.search-wrapper
         input(id="search", placeholder="Search" autocomplete="off")

--- a/pug/_navbar.pug
+++ b/pug/_navbar.pug
@@ -20,7 +20,7 @@ header
         li
           a 1.0.0
         li
-          a(href='http://archives.materializecss.com/0.100.2/' target='_blank') 0.100.2
+          a(href='http://archives.materializecss.com/0.100.2/' target='_blank' rel='noopener noreferrer') 0.100.2
     li(class="search")
       div.search-wrapper
         input(id="search", placeholder="Search" autocomplete="off")


### PR DESCRIPTION
## Proposed changes
Hello! Haven't had time to contribute in a while. I noticed the docs for 0.100.2 include a link back to the v1 beta docs. Clicking on that took me to materializecss.com, and I thought that was confusing since the latest ones on Github look very similar. I thought the best way to mitigate this issue was to open the older docs in a new window.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/v1-dev/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
