### PR TITLE
docs: allow only one click for copy code button

### DIFF
--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -246,7 +246,5 @@ function copyText() {
   copyBtn.insertAdjacentHTML('afterend', 
     `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
   )
-  copyBtn.classList.remove("waves-effect");
-  copyBtn.classList.remove("waves-light");
   copyBtn.classList.add("disabled");
 }

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -236,15 +236,17 @@
 function copyText() {
   const copiedText = document.getElementById('copiedText').textContent
   const textArea = document.createElement('textArea');
+  const copyBtn = document.getElementById("copyButton");
 
   textArea.textContent = copiedText;
   document.body.append(textArea);
   textArea.select();
   textArea.setSelectionRange(0, 99999)
   document.execCommand('copy');
-  document.getElementById('copyButton')
-    .insertAdjacentHTML('afterend', 
-      `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
-    )
-  document.getElementById("copyButton").onclick = "";
+  copyBtn.insertAdjacentHTML('afterend', 
+    `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
+  )
+  copyBtn.classList.remove("waves-effect");
+  copyBtn.classList.remove("waves-light");
+  copyBtn.classList.add("disabled");
 }

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -236,14 +236,15 @@
 function copyText() {
   const copiedText = document.getElementById('copiedText').textContent
   const textArea = document.createElement('textArea');
+
   textArea.textContent = copiedText;
   document.body.append(textArea);
   textArea.select();
   textArea.setSelectionRange(0, 99999)
   document.execCommand('copy');
   document.getElementById('copyButton')
-  .insertAdjacentHTML('afterend',
-  `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
-  )
+    .insertAdjacentHTML('afterend', 
+      `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
+    )
   document.getElementById("copyButton").onclick = "";
-  }
+}

--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -245,5 +245,5 @@ function copyText() {
   .insertAdjacentHTML('afterend',
   `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
   )
-  // alert("Code copied to clipboard: " + textArea.value);
+  document.getElementById("copyButton").onclick = "";
   }


### PR DESCRIPTION
## Proposed changes
Just a quick fix to my copy code button. I added a line to disallow multiple messages, aka the user can only click the button once.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/v1-dev/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
