### PR TITLE
Copy text without creating textarea and use single container for copy success message

### DIFF
--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -234,16 +234,19 @@
 
 // Copy Button
 function copyText() {
-  const copiedText = document.getElementById('copiedText').textContent
-  const textArea = document.createElement('textArea');
-  textArea.textContent = copiedText;
-  document.body.append(textArea);
-  textArea.select();
-  textArea.setSelectionRange(0, 99999)
-  document.execCommand('copy');
-  document.getElementById('copyButton')
-  .insertAdjacentHTML('afterend',
-  `<span style="margin-left:10px; font-size:14px;">Copied!</span>`
-  )
-  // alert("Code copied to clipboard: " + textArea.value);
-  }
+	const copiedText = document.querySelector("#copiedText");
+	const copyMsg = document.querySelector(".copyMessage");
+	
+	const selection = window.getSelection();
+	const range = document.createRange();
+	range.selectNodeContents(copiedText);
+	selection.removeAllRanges();
+	selection.addRange(range); // Select the text to be copied
+	document.execCommand("copy");
+	selection.removeAllRanges(); // Unselect after copying, so selection is not visible
+
+  copyMsg.style.opacity = 1; // Show message after copying
+	setTimeout(() => {
+		copyMsg.style.opacity = 0; // Hide message after a few seconds
+	}, 2000);
+}

--- a/pug/getting_started/getting_started_content.html
+++ b/pug/getting_started/getting_started_content.html
@@ -35,7 +35,8 @@
             <h5>CDN</h5>
             <p>You can find all the versions of the CDN at <a href="https://www.jsdelivr.com/package/npm/@materializecss/materialize">jsDelivr</a>.</p>
             <p><a class="waves-effect waves-light btn" id="copyButton" onclick="copyText()">Copy code <i
-              class="material-icons right">content_copy</i></a></p>
+              class="material-icons right">content_copy</i></a>
+              <span class="copyMessage" style="margin-left:10px; font-size:14px; transition:all 0.2s ease-in; opacity:0;">Copied!</span></p>
             <pre><code class="language-markup" id="copiedText">
     &lt;!-- Compiled and minified CSS -->
     &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.1.0-alpha/dist/css/materialize.min.css">


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
- Use a single message container to inform user when text is copied.
- Copy text without creating a textarea. Currently, the textarea appears at the bottom of the page. Screenshot below.

![Getting Started - Materialize - materializecss github io](https://user-images.githubusercontent.com/15064293/126879291-ed603fad-88d8-4462-90f4-1bf81cd0a5e5.png)

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/v1-dev/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
