### PR TITLE
docs: change to/add copy code icons

### DIFF
--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -233,20 +233,27 @@
 })(jQuery); // end of jQuery name space
 
 // Copy Button
-function copyText() {
-	const copiedText = document.querySelector("#copiedText");
-	const copyMsg = document.querySelector(".copyMessage");
-	
-	const selection = window.getSelection();
-	const range = document.createRange();
-	range.selectNodeContents(copiedText);
-	selection.removeAllRanges();
-	selection.addRange(range); // Select the text to be copied
-	document.execCommand("copy");
-	selection.removeAllRanges(); // Unselect after copying, so selection is not visible
+document.addEventListener('DOMContentLoaded', () => {
+  const copyBtn = Array.prototype.slice.call(
+    document.querySelectorAll(".copyButton")
+  );
 
-  copyMsg.style.opacity = 1; // Show message after copying
-	setTimeout(() => {
-		copyMsg.style.opacity = 0; // Hide message after a few seconds
-	}, 2000);
-}
+  const copiedText = Array.prototype.slice.call(
+    document.querySelectorAll(".copiedText")
+  );
+
+  const copyMsg = Array.prototype.slice.call(
+    document.querySelectorAll(".copyMessage")
+  );
+
+	copyBtn.forEach((copyBtn, i) => {
+		copyBtn.addEventListener("click", () => {
+			navigator.clipboard.writeText(copiedText[i].innerText);
+			copyMsg[i].style.opacity = 1;
+			setTimeout(() => {
+				copyMsg[i].style.opacity = 0;
+			}, 2000);
+		});
+	});
+});
+

--- a/pug/getting_started/getting_started_content.html
+++ b/pug/getting_started/getting_started_content.html
@@ -34,10 +34,10 @@
             <br>
             <h5>CDN</h5>
             <p>You can find all the versions of the CDN at <a href="https://www.jsdelivr.com/package/npm/@materializecss/materialize">jsDelivr</a>.</p>
-            <p><a class="waves-effect waves-light btn" id="copyButton" onclick="copyText()">Copy code <i
-              class="material-icons right">content_copy</i></a>
-              <span class="copyMessage" style="margin-left:10px; font-size:14px; transition:all 0.2s ease-in; opacity:0;">Copied!</span></p>
-            <pre><code class="language-markup" id="copiedText">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
     &lt;!-- Compiled and minified CSS -->
     &lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@materializecss/materialize@1.1.0-alpha/dist/css/materialize.min.css">
 
@@ -99,7 +99,10 @@
       <div class="col s12">
         <h5>HTML Setup</h5>
         <p>Next you just have to make sure you link the files properly in your webpage. Generally it is wise to import javascript files at the end of the body to reduce page load time. Follow the example below on how to import Materialize into your webpage.</p>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+            <i class="material-icons copyButton">content_copy</i>
+            <code class="language-markup copiedText">
   &lt;!DOCTYPE html>
   &lt;html>
     &lt;head>
@@ -118,7 +121,8 @@
       &lt;script type="text/javascript" src="js/materialize.min.js">&lt;/script>
     &lt;/body>
   &lt;/html>
-        </code></pre>
+            </code>
+          </pre>
       </div>
     </div>
 

--- a/pug/page-contents/autocomplete_content.html
+++ b/pug/page-contents/autocomplete_content.html
@@ -21,7 +21,10 @@
           </div>
         </div>
 
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="row">
     &lt;div class="col s12">
       &lt;div class="row">
@@ -33,7 +36,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="initialization" class="scrollspy section">
@@ -41,7 +45,10 @@
         <p>The data is a json object where the key is the matching string and the value is an optional image url.</p>
         <p>The key must be a text string. If you trust your data, or have properly sanitized your user input, you may
           use HTML by setting the option <code class="language-javascript">allowUnsafeHTML: true</code>.</p>
-        <pre><code class="language-javascript">
+          <pre style="padding-top: 0px;">
+            <span class="copyMessage">Copied!</span>
+            <i class="material-icons copyButton">content_copy</i>
+            <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.autocomplete');
     var instances = M.Autocomplete.init(elems, {
@@ -67,7 +74,8 @@
       },
     });
   });
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
 
@@ -135,12 +143,16 @@
         <p>This is the default compareFunction. You can write your own compareFunction by passing in a function with these same
           3 parameters. You can read more about how a compareFunction works
           <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort">here</a>.</p>
-        <pre><code class="language-javascript col s12">
+          <pre style="padding-top: 0px;">
+            <span class="copyMessage">Copied!</span>
+            <i class="material-icons copyButton">content_copy</i>
+            <code class="language-javascript col s12 copiedText">
   // Sort function for sorting autocomplete results
   function (a, b, inputString) {
     return a.indexOf(inputString) - b.indexOf(inputString);
   }
-        </code></pre>
+            </code>
+          </pre>
         <p>To disable sorting and use the values as they appear in the data object, use a falsy value.</p>
       </div>
 
@@ -150,7 +162,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
   var instance = M.Autocomplete.getInstance(elem);
 
   /* jQuery Method Calls
@@ -160,7 +175,8 @@
     $('.autocomplete').autocomplete('methodName');
     $('.autocomplete').autocomplete('methodName', paramName);
   */
-        </code></pre>
+              </code>
+            </pre>
         </blockquote>
         <h5 class="method-header">
           .open();

--- a/pug/page-contents/badges_content.html
+++ b/pug/page-contents/badges_content.html
@@ -18,14 +18,18 @@
               <a href="#!" class="collection-item">Alan</a>
               <a href="#!" class="collection-item"><span class="badge">14</span>Alan</a>
             </div>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="collection">
     &lt;a href="#!" class="collection-item">&lt;span class="badge">1&lt;/span>Alan&lt;/a>
     &lt;a href="#!" class="collection-item">&lt;span class="new badge">4&lt;/span>Alan&lt;/a>
     &lt;a href="#!" class="collection-item">Alan&lt;/a>
     &lt;a href="#!" class="collection-item">&lt;span class="badge">14&lt;/span>Alan&lt;/a>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>

--- a/pug/page-contents/breadcrumbs_content.html
+++ b/pug/page-contents/breadcrumbs_content.html
@@ -22,7 +22,10 @@
             </nav>
 
             <br><br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;nav>
     &lt;div class="nav-wrapper">
       &lt;div class="col s12">
@@ -32,7 +35,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/nav>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>

--- a/pug/page-contents/buttons_content.html
+++ b/pug/page-contents/buttons_content.html
@@ -10,18 +10,26 @@
         <a class="waves-effect waves-light btn">button</a>
         <a class="waves-effect waves-light btn"><i class="material-icons left">cloud</i>button</a>
         <a class="waves-effect waves-light btn"><i class="material-icons right">cloud</i>button</a>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
 &lt;a class="waves-effect waves-light btn">button&lt;/a>
 &lt;a class="waves-effect waves-light btn">&lt;i class="material-icons left">cloud&lt;/i>button&lt;/a>
 &lt;a class="waves-effect waves-light btn">&lt;i class="material-icons right">cloud&lt;/i>button&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
       </div>
       <div id="floating" class="section scrollspy">
         <h3 class="header">Floating</h3>
         <a class="btn-floating waves-effect waves-light btn-large red"><i class="material-icons">add</i></a><br><br>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
   &lt;a class="btn-floating btn-large waves-effect waves-light red">&lt;i class="material-icons">add&lt;/i>&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
         <br>
 
         <h5>Floating Action Button</h5>
@@ -31,19 +39,27 @@
         <h3 class="header">Flat</h3>
         <p>Flat buttons are used to reduce excessive layering. For example, flat buttons are usually used for actions within a card or modal so there aren't too many overlapping shadows.</p>
         <a class="waves-effect waves-teal btn-flat">Button</a>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
   &lt;a class="waves-effect waves-teal btn-flat">Button&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
       </div>
       <div id="submit" class="section scrollspy">
         <h3 class="header">Submit Button</h3>
         <p>When you use a button to submit a form, instead of using a input tag, use a button tag with a type submit</p>
         <button class="btn waves-effect waves-light" type="submit" name="action">Submit<i class="material-icons right">send</i></button>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;button class="btn waves-effect waves-light" type="submit" name="action">Submit
     &lt;i class="material-icons right">send&lt;/i>
   &lt;/button>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="large" class="section scrollspy">
@@ -52,11 +68,15 @@
         <a class="waves-effect waves-light btn-large">Button</a>
         <a class="waves-effect waves-light btn-large"><i class="material-icons left">cloud</i>button</a>
         <a class="waves-effect waves-light btn-large"><i class="material-icons right">cloud</i>button</a>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
 &lt;a class="waves-effect waves-light btn-large">Button&lt;/a>
 &lt;a class="waves-effect waves-light btn-large">&lt;i class="material-icons left">cloud&lt;/i>button&lt;/a>
 &lt;a class="waves-effect waves-light btn-large">&lt;i class="material-icons right">cloud&lt;/i>button&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
 
@@ -66,11 +86,15 @@
         <a class="waves-effect waves-light btn-small">Button</a>
         <a class="waves-effect waves-light btn-small"><i class="material-icons left">cloud</i>button</a>
         <a class="waves-effect waves-light btn-small"><i class="material-icons right">cloud</i>button</a>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
 &lt;a class="waves-effect waves-light btn-small">Button&lt;/a>
 &lt;a class="waves-effect waves-light btn-small">&lt;i class="material-icons left">cloud&lt;/i>button&lt;/a>
 &lt;a class="waves-effect waves-light btn-small">&lt;i class="material-icons right">cloud&lt;/i>button&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
 
@@ -81,12 +105,16 @@
         <a class="btn disabled">Button</a>
         <a class="btn-flat disabled">Button</a>
         <a class="btn-floating disabled"><i class="material-icons">add</i></a>
-        <pre><code class="language-markup col s12">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup col s12 copiedText">
 &lt;a class="btn-large disabled">Button&lt;/a>
 &lt;a class="btn disabled">Button&lt;/a>
 &lt;a class="btn-flat disabled">Button&lt;/a>
 &lt;a class="btn-floating disabled">&lt;i class="material-icons">add&lt;/i>&lt;/a>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
     </div>

--- a/pug/page-contents/cards_content.html
+++ b/pug/page-contents/cards_content.html
@@ -23,7 +23,10 @@
 
             <div class="col s12">
               <br>
-              <pre><code class="language-markup">
+              <pre style="padding-top: 0px;">
+                <span class="copyMessage">Copied!</span>
+                <i class="material-icons copyButton">content_copy</i>
+                <code class="language-markup copiedText">
   &lt;div class="row">
     &lt;div class="col s12 m6">
       &lt;div class="card blue-grey darken-1">
@@ -39,7 +42,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>
@@ -71,7 +75,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="row">
     &lt;div class="col s12 m7">
       &lt;div class="card">
@@ -89,7 +96,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>
@@ -138,7 +146,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="row">
     &lt;div class="col s12 m6">
       &lt;div class="card">
@@ -153,7 +164,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>
@@ -186,7 +198,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="col s12 m7">
     &lt;h2 class="header">Horizontal Card&lt;/h2>
     &lt;div class="card horizontal">
@@ -203,7 +218,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>
@@ -236,7 +252,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card">
     &lt;div class="card-image waves-effect waves-block waves-light">
       &lt;img class="activator" src="images/office.jpg">
@@ -250,7 +269,8 @@
       &lt;p>Here is some more information about this product that is only revealed once clicked on.&lt;/p>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
         <div class="row">
@@ -311,7 +331,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card sticky-action">
     ...
 
@@ -319,7 +342,8 @@
 
     &lt;div class="card-reveal">...&lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>
@@ -332,7 +356,10 @@
             <p class="caption">
              You can add tabs to your cards by adding a dividing <code class="language-markup">cards-tabs</code> div inbetween your header content and your tab content.
             </p>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card">
     &lt;div class="card-content">
       &lt;p>I am a very simple card. I am good at containing small bits of information. I am convenient because I require little markup to use effectively.&lt;/p>
@@ -349,7 +376,9 @@
       &lt;div id="test5">Test 2&lt;/div>
       &lt;div id="test6">Test 3&lt;/div>
     &lt;/div>
-  &lt;/div></code></pre>
+  &lt;/div> 
+              </code>
+            </pre>
           </div>
         </div>
         <div class="row">
@@ -416,11 +445,15 @@
           <div class="col s12">
             <h3 class="header">Card Sizes</h3>
             <p class="caption">If you want to have uniformly sized cards, you can use our premade size classes. Just add the size class in addition to the card class. </p>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card small">
     &lt;!-- Card Content -->
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
         <div class="row">
@@ -515,7 +548,10 @@
           </div>
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="row">
     &lt;div class="col s12 m5">
       &lt;div class="card-panel teal">
@@ -525,7 +561,8 @@
       &lt;/div>
     &lt;/div>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>

--- a/pug/page-contents/carousel_content.html
+++ b/pug/page-contents/carousel_content.html
@@ -28,7 +28,10 @@
         </div>
         <br>
 
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="carousel">
     &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/250x250_a.png">&lt;/a>
     &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/250x250_b.png">&lt;/a>
@@ -36,13 +39,17 @@
     &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/250x250_d.png">&lt;/a>
     &lt;a class="carousel-item" href="#five!">&lt;img src="images/placeholder/250x250_e.png">&lt;/a>
   &lt;/div>
-      </code></pre>
+          </code>
+        </pre>
       </div>
 
       <!--  Options Section  -->
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.carousel');
     var instances = M.Carousel.init(elems, {
@@ -57,7 +64,8 @@
       // specify options here
     });
   });
-      </code></pre>
+          </code>
+        </pre>
         <br>
       </div>
 
@@ -138,7 +146,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
   var instance = M.Carousel.getInstance(elem);
 
   /* jQuery Method Calls
@@ -148,7 +159,8 @@
     $('.carousel').carousel('methodName');
     $('.carousel').carousel('methodName', paramName);
   */
-        </code></pre>
+              </code>
+            </pre>
         </blockquote>
         <h5 class="method-header">
           .next();
@@ -263,16 +275,23 @@ instance.destroy();
         </div>
         <br>
 
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="carousel carousel-slider">
     &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/800x400_a.jpg">&lt;/a>
     &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/800x400_b.jpg">&lt;/a>
     &lt;a class="carousel-item" href="#three!">&lt;img src="images/placeholder/800x400_c.jpg">&lt;/a>
     &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/800x400_d.jpg">&lt;/a>
   &lt;/div>
-        </code></pre>
+          </code>
+        </pre>
 
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   var instance = M.Carousel.init({
     fullWidth: true
   });
@@ -282,7 +301,8 @@ instance.destroy();
   $('.carousel.carousel-slider').carousel({
     fullWidth: true
   });
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <!-- Special Options Section  -->
@@ -316,7 +336,10 @@ instance.destroy();
           </div>
         </div>
         <br>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="carousel carousel-slider center">
     &lt;div class="carousel-fixed-item center">
       &lt;a class="btn waves-effect white grey-text darken-text-2">button&lt;/a>
@@ -338,8 +361,12 @@ instance.destroy();
       &lt;p class="white-text">This is your fourth panel&lt;/p>
     &lt;/div>
   &lt;/div>
-        </code></pre>
-        <pre><code class="language-javascript">
+          </code>
+        </pre>
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   var instance = M.Carousel.init({
     fullWidth: true,
     indicators: true
@@ -351,7 +378,8 @@ instance.destroy();
     fullWidth: true,
     indicators: true
   });
-        </code></pre>
+          </code>
+        </pre>
       </div>
     </div>
 

--- a/pug/page-contents/checkboxes_content.html
+++ b/pug/page-contents/checkboxes_content.html
@@ -46,7 +46,10 @@
         </form>
 
         <br>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;form action="#">
     &lt;p>
       &lt;label>

--- a/pug/page-contents/chips_content.html
+++ b/pug/page-contents/chips_content.html
@@ -21,12 +21,16 @@
         <p class="caption">
           To create a contact chip just add an img inside.
         </p>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="chip">
     &lt;img src="images/yuna.jpg" alt="Contact Person">
     Jane Doe
   &lt;/div>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="tag" class="section scrollspy">
@@ -35,12 +39,16 @@
           To create a tag chip just add a close icon inside with the class
           <code class="language-markup">close</code>.
         </p>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;div class="chip">
     Tag
     &lt;i class="close material-icons">close&lt;/i>
   &lt;/div>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="basic" class="section scrollspy">
@@ -60,7 +68,10 @@
       </div>
 
       <div id="options" class="section scrollspy">
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;!-- Default with no input (automatically generated)  -->
   &lt;div class="chips">&lt;/div>
   &lt;div class="chips chips-initial">&lt;/div>
@@ -71,9 +82,13 @@
   &lt;div class="chips">
     &lt;input class="custom-class">
   &lt;/div>
-        </code></pre>
+          </code>
+        </pre>
         <h3 class="header">Initialization</h3>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.chips');
     var instances = M.Chips.init(elems, {
@@ -111,14 +126,19 @@
       }
     });
   });
-        </code></pre>
+          </code>
+        </pre>
         <p class="caption">Chip data object</p>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   var chip = {
     tag: 'chip content',
     image: '', //optional
   };
-        </code></pre>
+          </code>
+        </pre>
 
         <br>
         <h3 class="header">Options</h3>
@@ -200,7 +220,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
     var instance = M.Chips.getInstance(elem);
 
     /* jQuery Method Calls
@@ -210,7 +233,8 @@
       $('.chips').chips('methodName');
       $('.chips').chips('methodName', paramName);
     */
-          </code></pre>
+              </code>
+            </pre>
         </blockquote>
 
         <h5 class="method-header">

--- a/pug/page-contents/collapsible_content.html
+++ b/pug/page-contents/collapsible_content.html
@@ -43,7 +43,10 @@
           </ul>
           <br>
 
-          <pre><code class="language-markup">
+          <pre style="padding-top: 0px;">
+            <span class="copyMessage">Copied!</span>
+            <i class="material-icons copyButton">content_copy</i>
+            <code class="language-markup copiedText">
   &lt;ul class="collapsible">
     &lt;li>
       &lt;div class="collapsible-header">&lt;i class="material-icons">filter_drama&lt;/i>First&lt;/div>
@@ -58,12 +61,16 @@
       &lt;div class="collapsible-body">&lt;span>Lorem ipsum dolor sit amet.&lt;/span>&lt;/div>
     &lt;/li>
   &lt;/ul>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="initialization" class="section scrollspy">
         <h3 class="header">Initialization</h3>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.collapsible');
     var instances = M.Collapsible.init(elems, {
@@ -78,7 +85,8 @@
       // specify options here
     });
   });
-        </code></pre>
+          </code>
+        </pre>
 
         <br>
         <br>
@@ -119,11 +127,15 @@
             </div>
           </li>
         </ul>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;li class="active">
     &lt;div class="collapsible-header">&lt;i class="material-icons">place&lt;/i>Second&lt;/div>
   &lt;/li>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="options" class="scrollspy section">
@@ -197,7 +209,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
   var instance = M.Collapsible.getInstance(elem);
 
   /* jQuery Method Calls
@@ -207,7 +222,8 @@
     $('.collapsible').collapsible('methodName');
     $('.collapsible').collapsible('methodName', paramName);
   */
-        </code></pre>
+              </code>
+            </pre>
         </blockquote>
         <h5 class="method-header">
           .open();

--- a/pug/page-contents/collections_content.html
+++ b/pug/page-contents/collections_content.html
@@ -16,14 +16,18 @@
               <li class="collection-item">Alvin</li>
               <li class="collection-item">Alvin</li>
             </ul>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
     &lt;ul class="collection">
       &lt;li class="collection-item">Alvin&lt;/li>
       &lt;li class="collection-item">Alvin&lt;/li>
       &lt;li class="collection-item">Alvin&lt;/li>
       &lt;li class="collection-item">Alvin&lt;/li>
     &lt;/ul>
-            </code></pre>
+              </code>
+            </pre>
             <br>
           </div>
         </div>
@@ -39,14 +43,18 @@
               <a href="#!" class="collection-item">Alvin</a>
               <a href="#!" class="collection-item">Alvin</a>
             </div>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
       &lt;div class="collection">
         &lt;a href="#!" class="collection-item">Alvin&lt;/a>
         &lt;a href="#!" class="collection-item active">Alvin&lt;/a>
         &lt;a href="#!" class="collection-item">Alvin&lt;/a>
         &lt;a href="#!" class="collection-item">Alvin&lt;/a>
       &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>
@@ -62,7 +70,10 @@
               <li class="collection-item">Alvin</li>
               <li class="collection-item">Alvin</li>
             </ul>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
       &lt;ul class="collection with-header">
         &lt;li class="collection-header">&lt;h4>First Names&lt;/h4>&lt;/li>
         &lt;li class="collection-item">Alvin&lt;/li>
@@ -70,7 +81,8 @@
         &lt;li class="collection-item">Alvin&lt;/li>
         &lt;li class="collection-item">Alvin&lt;/li>
       &lt;/ul>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>
@@ -87,7 +99,10 @@
               <li class="collection-item">Alvin<a href="#!" class="secondary-content"><i class="material-icons">send</i></a></li>
               <li class="collection-item">Alvin<a href="#!" class="secondary-content"><i class="material-icons">send</i></a></li>
             </ul>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
       &lt;ul class="collection with-header">
         &lt;li class="collection-header">&lt;h4>First Names&lt;/h4>&lt;/li>
         &lt;li class="collection-item">&lt;div>Alvin&lt;a href="#!" class="secondary-content">&lt;i class="material-icons">send&lt;/i>&lt;/a>&lt;/div>&lt;/li>
@@ -95,7 +110,8 @@
         &lt;li class="collection-item">&lt;div>Alvin&lt;a href="#!" class="secondary-content">&lt;i class="material-icons">send&lt;/i>&lt;/a>&lt;/div>&lt;/li>
         &lt;li class="collection-item">&lt;div>Alvin&lt;a href="#!" class="secondary-content">&lt;i class="material-icons">send&lt;/i>&lt;/a>&lt;/div>&lt;/li>
       &lt;/ul>
-            </code></pre>
+              </code>
+            </pre>
           </div>
 
         </div>
@@ -139,7 +155,10 @@
                 <a href="#!" class="secondary-content"><i class="material-icons">grade</i></a>
               </li>
             </ul>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;ul class="collection">
     &lt;li class="collection-item avatar">
       &lt;img src="images/yuna.jpg" alt="" class="circle">
@@ -174,7 +193,8 @@
       &lt;a href="#!" class="secondary-content">&lt;i class="material-icons">grade&lt;/i>&lt;/a>
     &lt;/li>
   &lt;/ul>
-            </code></pre>
+              </code>
+            </pre>
           </div>
 
         </div>

--- a/pug/page-contents/color_content.html
+++ b/pug/page-contents/color_content.html
@@ -13,9 +13,13 @@
           <div class="col s12 m9">
             <p>To apply a background color, just add the color name and light/darkness as a class to the element.</p>
             <div class="card-panel teal lighten-2">This is a card panel with a teal lighten-2 class</div>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card-panel teal lighten-2">This is a card panel with a teal lighten-2 class&lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
 
           <br>
@@ -24,11 +28,15 @@
           <div class="col s12 m9">
             <p>To apply a text color, just append <code class="languague-markup">-text</code> to the color class like this:</p>
             <div class="card-panel"><span class="blue-text text-darken-2">This is a card panel with dark blue text</span></div>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
   &lt;div class="card-panel">
     &lt;span class="blue-text text-darken-2">This is a card panel with dark blue text&lt;/span>
   &lt;/div>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
       </div>

--- a/pug/page-contents/css-transitions_content.html
+++ b/pug/page-contents/css-transitions_content.html
@@ -16,7 +16,10 @@
         <a id="scale-demo-trigger" href="#!" class="btn right">Toggle Scale</a>
 
         <br><br>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;!-- Scaled in -->
   &lt;a id="scale-demo" href="#!" class="btn-floating btn-large scale-transition">
     &lt;i class="material-icons">add&lt;/i>
@@ -26,7 +29,8 @@
   &lt;a id="scale-demo" href="#!" class="btn-floating btn-large scale-transition scale-out">
     &lt;i class="material-icons">add&lt;/i>
   &lt;/a>
-  </code></pre>
+          </code>
+        </pre>
       </div>
 
     </div>

--- a/pug/page-contents/dropdown_content.html
+++ b/pug/page-contents/dropdown_content.html
@@ -31,7 +31,10 @@
         </ul>
         <br>
         <br>
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;!-- Dropdown Trigger -->
   &lt;a class='dropdown-trigger btn' href='#' data-target='dropdown1'>Drop Me!&lt;/a>
 
@@ -44,12 +47,16 @@
     &lt;li>&lt;a href="#!">&lt;i class="material-icons">view_module&lt;/i>four&lt;/a>&lt;/li>
     &lt;li>&lt;a href="#!">&lt;i class="material-icons">cloud&lt;/i>five&lt;/a>&lt;/li>
   &lt;/ul>
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="initialization" class="section scrollspy">
         <h3 class="header">Initialization</h3>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.dropdown-trigger');
     var instances = M.Dropdown.init(elems, {
@@ -64,7 +71,8 @@
       // specify options here
     });
   });
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
 
@@ -168,7 +176,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
     var instance = M.Dropdown.getInstance(elem);
 
     /* jQuery Method Calls
@@ -178,7 +189,8 @@
       $('.dropdown-trigger').dropdown('methodName');
       $('.dropdown-trigger').dropdown('methodName', paramName);
     */
-          </code></pre>
+              </code>
+            </pre>
         </blockquote>
         <h5 class="method-header">
           .open();

--- a/pug/page-contents/featureDiscovery_content.html
+++ b/pug/page-contents/featureDiscovery_content.html
@@ -28,7 +28,10 @@
           </div>
         </div>
 
-        <pre><code class="language-markup">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-markup copiedText">
   &lt;!-- Element Showed -->
   &lt;a id="menu" class="waves-effect waves-light btn btn-floating" >&lt;i class="material-icons">menu&lt;/i>&lt;/a>
 
@@ -39,12 +42,16 @@
       &lt;p>A bunch of text&lt;/p>
     &lt;/div>
   &lt;/div>
-          </code></pre>
+            </code>
+          </pre>
       </div>
 
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.tap-target');
     var instances = M.TapTarget.init(elems, {
@@ -59,7 +66,8 @@
       // specify options here
     });
   });
-          </code></pre>
+            </code>
+          </pre>
         <br>
       </div>
 
@@ -99,7 +107,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
   var instance = M.TapTarget.getInstance(elem);
 
   /* jQuery Method Calls
@@ -109,7 +120,8 @@
     $('.tap-target').tapTarget('methodName');
     $('.tap-target').tapTarget('methodName', paramName);
   */
-            </code></pre>
+              </code>
+            </pre>
         </blockquote>
         <h5 class="method-header">
           .open();

--- a/pug/page-contents/floating-action-button-content.html
+++ b/pug/page-contents/floating-action-button-content.html
@@ -10,7 +10,10 @@
 
       </div>
 
-      <pre><code class="language-markup">
+      <pre style="padding-top: 0px;">
+        <span class="copyMessage">Copied!</span>
+        <i class="material-icons copyButton">content_copy</i>
+        <code class="language-markup copiedText">
 &lt;div class="fixed-action-btn">
   &lt;a class="btn-floating btn-large red">
     &lt;i class="large material-icons">mode_edit&lt;/i>
@@ -22,12 +25,16 @@
     &lt;li>&lt;a class="btn-floating blue">&lt;i class="material-icons">attach_file&lt;/i>&lt;/a>&lt;/li>
   &lt;/ul>
 &lt;/div>
-      </code></pre>
+        </code>
+      </pre>
 
 
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h5>
-          <pre><code class="language-javascript">
+          <pre style="padding-top: 0px;">
+            <span class="copyMessage">Copied!</span>
+            <i class="material-icons copyButton">content_copy</i>
+            <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.fixed-action-btn');
     var instances = M.FloatingActionButton.init(elems, {
@@ -42,7 +49,8 @@
       // specify options here
     });
   });
-        </code></pre>
+            </code>
+          </pre>
           <br>
       </div>
 
@@ -91,7 +99,10 @@
         <blockquote>
           <p>Because jQuery is no longer a dependency, all the methods are called on the plugin instance. You can get the plugin
             instance like this: </p>
-          <pre><code class="language-javascript col s12">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-javascript col s12 copiedText">
   var instance = M.FloatingActionButton.getInstance(elem);
 
   /* jQuery Method Calls
@@ -101,7 +112,8 @@
     $('.fixed-action-btn').floatingActionButton('methodName');
     $('.fixed-action-btn').floatingActionButton('methodName', paramName);
   */
-          </code></pre>
+            </code>
+          </pre>
         </blockquote>
         <h5 class="method-header">
           .open();
@@ -197,14 +209,18 @@ instance.destroy();
             </ul>
           </div>
         </div>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.fixed-action-btn');
     var instances = M.FloatingActionButton.init(elems, {
       direction: 'left'
     });
   });
-        </code></pre>
+          </code>
+        </pre>
 
         <div class="fixed-action-btn" style="bottom: 45px; right: 24px;">
           <a class="btn-floating btn-large red">
@@ -271,7 +287,10 @@ instance.destroy();
             </ul>
           </div>
         </div>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.fixed-action-btn');
     var instances = M.FloatingActionButton.init(elems, {
@@ -279,7 +298,8 @@ instance.destroy();
       hoverEnabled: false
     });
   });
-        </code></pre>
+          </code>
+        </pre>
       </div>
 
       <div id="toolbar" class="scrollspy section">
@@ -287,7 +307,10 @@ instance.destroy();
         <p>Instead of displaying individual button options, you can transition your FAB into a toolbar on click. Just add the
           <code class="language-markup">toolbar</code> class to the FAB.</p>
         <iframe src="fab-toolbar-demo.html" frameborder="0" width="100%" height="100px"></iframe>
-        <pre><code class="language-javascript">
+        <pre style="padding-top: 0px;">
+          <span class="copyMessage">Copied!</span>
+          <i class="material-icons copyButton">content_copy</i>
+          <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.fixed-action-btn');
     var instances = M.FloatingActionButton.init(elems, {

--- a/pug/page-contents/footer_content.html
+++ b/pug/page-contents/footer_content.html
@@ -34,7 +34,10 @@
         <div class="row">
           <div class="col s12">
             <br>
-            <pre><code class="language-markup">
+            <pre style="padding-top: 0px;">
+              <span class="copyMessage">Copied!</span>
+              <i class="material-icons copyButton">content_copy</i>
+              <code class="language-markup copiedText">
         &lt;footer class="page-footer">
           &lt;div class="container">
             &lt;div class="row">
@@ -60,7 +63,8 @@
             &lt;/div>
           &lt;/div>
         &lt;/footer>
-            </code></pre>
+              </code>
+            </pre>
           </div>
         </div>
 
@@ -72,7 +76,10 @@
         <p>Note: This may cause issues in Internet Explorer which has weak support for flexbox.</p>
       </div>
 
-      <pre><code class="language-css">
+      <pre style="padding-top: 0px;">
+        <span class="copyMessage">Copied!</span>
+        <i class="material-icons copyButton">content_copy</i>
+        <code class="language-css copiedText">
   body {
     display: flex;
     min-height: 100vh;
@@ -82,7 +89,8 @@
   main {
     flex: 1 0 auto;
   }
-      </code></pre>
+        </code>
+      </pre>
 
     </div>
 

--- a/pug/parallax/parallax_content.html
+++ b/pug/parallax/parallax_content.html
@@ -29,7 +29,10 @@
     </div>
     <div class="row container">
       <h4 class="light">Parallax Demo HTML</h4>
-      <pre><code class="language-markup col s12">
+      <pre style="padding-top: 0px;">
+        <span class="copyMessage">Copied!</span>
+        <i class="material-icons copyButton">content_copy</i>
+        <code class="language-markup col s12" id="copiedText">
   &lt;div class="parallax-container">
     &lt;div class="parallax">&lt;img src="images/parallax1.jpg">&lt;/div>
   &lt;/div>
@@ -42,7 +45,8 @@
   &lt;div class="parallax-container">
     &lt;div class="parallax">&lt;img src="images/parallax2.jpg">&lt;/div>
   &lt;/div>
-      </code></pre>
+        </code>
+      </pre>
     </div>
   </div>
   <div class="parallax-container">

--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -653,6 +653,27 @@ code[class*="language-"] {
   background: rgba(246, 246, 246, .3);
 }
 
+// copy code icons
+.copyMessage, .copyButton {
+  color: #757575; 
+  position: absolute; 
+}
+
+.copyMessage {
+  font-size: 14px;
+	transition: all 0.2s ease-in;
+	opacity: 0;
+	right: 45px;
+	top: 15px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu,Cantarell, "Helvetica Neue", sans-serif;
+}
+
+.copyButton {
+  top: 10px; 
+  right: 10px; 
+  cursor: pointer;
+}
+
 .toc-wrapper {
   &.pin-bottom {
     margin-top: 84px;


### PR DESCRIPTION
I've added the first run of 2 copy code icons to the Getting Started page. The Clipboard API doesn't seem to work locally but I imagine will work when we push the changes live. Here is a codepen of the changes for reference as well:

https://codepen.io/christinavoudouris/pen/oNWqYLK

If these look good, I can go ahead and add them throughout the site.
