### PR TITLE
docs: edit README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ cd materialize
 npm install
 ```
 
-Then run `npm run dev` to compile the documentation. When it finishes, open a new browser window and navigate to `localhost:8000`. We use [BrowserSync](https://www.browsersync.io/) to display the documentation.
+Then run `npm run dev` to compile the documentation. When it finishes, open a new browser window and navigate to `localhost:8000/docs`. We use [BrowserSync](https://www.browsersync.io/) to display the documentation.
 
 ### Documentation for previous releases
 Previous releases and their documentation are available for [download](https://github.com/materializecss/materialize/releases).


### PR DESCRIPTION
I think it's confusing to navigate to localhost:8000 and see a blank screen when the doc can say to navigate directly to the docs by going to localhost:8000/docs. 

Also see issue #160 I recently created.