### PR TITLE
fix: Waves concat order

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,38 @@
 const sass = require('sass');
 
 module.exports = function(grunt) {
-  let concatFile = 'temp/js/materialize_concat.js.map';
+  const concatFile = 'temp/js/materialize_concat.js.map';
+  const jsFiles = [
+    'js/cash.js',
+    'js/waves.js',
+    'js/component.js',
+    'js/global.js',
+    'js/anime.min.js',
+    'js/collapsible.js',
+    'js/dropdown.js',
+    'js/modal.js',
+    'js/materialbox.js',
+    'js/parallax.js',
+    'js/tabs.js',
+    'js/tooltip.js',
+    'js/toasts.js',
+    'js/sidenav.js',
+    'js/scrollspy.js',
+    'js/autocomplete.js',
+    'js/forms.js',
+    'js/slider.js',
+    'js/cards.js',
+    'js/chips.js',
+    'js/pushpin.js',
+    'js/buttons.js',
+    'js/datepicker.js',
+    'js/timepicker.js',
+    'js/characterCounter.js',
+    'js/carousel.js',
+    'js/tapTarget.js',
+    'js/select.js',
+    'js/range.js'
+  ];
 
   // configure the tasks
   let config = {
@@ -165,37 +196,7 @@ module.exports = function(grunt) {
       },
       dist: {
         // the files to concatenate
-        src: [
-          'js/cash.js',
-          'js/component.js',
-          'js/global.js',
-          'js/anime.min.js',
-          'js/collapsible.js',
-          'js/dropdown.js',
-          'js/modal.js',
-          'js/materialbox.js',
-          'js/parallax.js',
-          'js/tabs.js',
-          'js/tooltip.js',
-          'js/waves.js',
-          'js/toasts.js',
-          'js/sidenav.js',
-          'js/scrollspy.js',
-          'js/autocomplete.js',
-          'js/forms.js',
-          'js/slider.js',
-          'js/cards.js',
-          'js/chips.js',
-          'js/pushpin.js',
-          'js/buttons.js',
-          'js/datepicker.js',
-          'js/timepicker.js',
-          'js/characterCounter.js',
-          'js/carousel.js',
-          'js/tapTarget.js',
-          'js/select.js',
-          'js/range.js'
-        ],
+        src: jsFiles,
         // the location of the resulting JS file
         dest: 'temp/js/materialize.js'
       },
@@ -205,37 +206,7 @@ module.exports = function(grunt) {
           sourceMap: true,
           sourceMapStyle: 'link'
         },
-        src: [
-          'js/cash.js',
-          'js/component.js',
-          'js/global.js',
-          'js/anime.min.js',
-          'js/collapsible.js',
-          'js/dropdown.js',
-          'js/modal.js',
-          'js/materialbox.js',
-          'js/parallax.js',
-          'js/tabs.js',
-          'js/tooltip.js',
-          'js/waves.js',
-          'js/toasts.js',
-          'js/sidenav.js',
-          'js/scrollspy.js',
-          'js/autocomplete.js',
-          'js/forms.js',
-          'js/slider.js',
-          'js/cards.js',
-          'js/chips.js',
-          'js/pushpin.js',
-          'js/buttons.js',
-          'js/datepicker.js',
-          'js/timepicker.js',
-          'js/characterCounter.js',
-          'js/carousel.js',
-          'js/tapTarget.js',
-          'js/select.js',
-          'js/range.js'
-        ],
+        src: jsFiles,
         // the location of the resulting JS file
         dest: 'temp/js/materialize_concat.js'
       }


### PR DESCRIPTION
## Proposed changes
There's a breaking change when we updated the Waves 0.6 to Waves 0.7. The Waves 0.7 now have `module.exports`, that inference with our `module.exports`. This becomes a problem when we want to use materializecss with `require` function (usually in a **node environment** like testing a React app, not in the browser).

I also merged the same arrays into one variable `jsFile`.

There should be no breaking change, but let me know if this ordering change somehow breaking something.

## Code Example:
```
global.M = require("@materializecss/materialize");
console.log(M);
```
Output on materialize 1.0
```
  <ref *1> {
      jQueryLoaded: false,
      default: [Circular *1],
      version: '1.0.0',
      keys: { TAB: 9, ENTER: 13, ESC: 27, ARROW_UP: 38, ARROW_DOWN: 40 },
      tabPressed: false,
      keyDown: false,
      initializeJqueryWrapper: [Function (anonymous)],
      AutoInit: [Function (anonymous)],
      ...
```
Output on materialize 1.1-alpha
```
    {
      init: [Function (anonymous)],
      attach: [Function (anonymous)],
      ripple: [Function (anonymous)],
      calm: [Function (anonymous)],
      displayEffect: [Function (anonymous)]
    }
```

As you can see, the `M` in the materialize 1.1-alpha is not from materialize, but from the Waves.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
