### PR TITLE
docs: rework about and home page to mention this is the community fork

### DIFF
--- a/pug/about/about_content.html
+++ b/pug/about/about_content.html
@@ -52,7 +52,23 @@
       <!--  About the Team-->
       <div id="team" class="section scrollspy">
         <h2 class="header">Meet the Team</h2>
-        <p class="caption">We are a team of students from Carnegie Mellon University.</p>
+        
+        <h5>The community</h5>
+
+        <p class="caption">Due to inactivity of the original developers, MaterializeCSS has been forked by a community of enthusiasts, which continues to be fully maintained by open source principes since 2021.<br>
+        Without the many contributors who participated in this fork, this project would probably not have received any updates anymore :</p>
+
+        <div class="center">
+          <div class="image-container">
+            <img src="https://contrib.rocks/image?repo=materializecss/materialize&max=24" style="width:100%;">
+          </div>
+        </div>
+
+        <h5>The original team</h5>
+        <p class="caption">MaterializeCSS was originally launched in 2014 by a team of students from Carnegie Mellon University.
+After 4 years of development, the latest official release have been released in september 2018 and received more than
+38K stars on github.</p>
+  
         <div class="center">
           <div class="image-container">
             <img src="images/materialize_team.jpeg" style="width:100%;">

--- a/pug/about/about_content.html
+++ b/pug/about/about_content.html
@@ -66,7 +66,7 @@
 
         <h5>The original team</h5>
         <p class="caption">MaterializeCSS was originally launched in 2014 by a team of students from Carnegie Mellon University.
-After 4 years of development, the latest official release have been released in september 2018 and received more than
+After 4 years of development, the latest official release was released in September 2018 and received more than
 38K stars on github.</p>
   
         <div class="center">

--- a/pug/index/index_content.html
+++ b/pug/index/index_content.html
@@ -33,7 +33,7 @@
         <div class="row">
             <div class="col s12 m10 offset-m1">
               <p class="grey-text" style="font-size: 0.8em;">Note : This is a community-managed fork of the official MaterializeCSS library.
-                Since the project's support have been dropped by the original team, this version is 100% community-powered, meaning that bug fixes or new features
+                Since the project's support has been dropped by the original team, this version is 100% community-powered, meaning that bug fixes or new features
                 are implemented by volunteers but are not official.</p>
             </div>
         </div>

--- a/pug/index/index_content.html
+++ b/pug/index/index_content.html
@@ -5,7 +5,7 @@
               <h1 class="header">Materialize</h1>
             </div>
             <div class="col s12 m8 offset-m2">
-              <h4 class="light">A modern responsive front-end framework based on Material Design</h4>
+              <h4 class="light">Simple. Built on open source. The responsive front-end library based on Google's Material Design.</h4>
             </div>
           </div>
           <div class="row center">
@@ -13,7 +13,6 @@
           </div>
           <div class="row center"><a class="current-version-number" href="https://github.com/materializecss/materialize">Release: 1.1.0-alpha</a></div>
           <br>
-
         </div>
         <div class="github-commit">
           <div class="container">
@@ -31,6 +30,13 @@
             </div>
           </div>
         </div>
+        <div class="row">
+            <div class="col s12 m10 offset-m1">
+              <p class="grey-text" style="font-size: 0.8em;">Note : This is a community-managed fork of the official MaterializeCSS library.
+                Since the project's support have been dropped by the original team, this version is 100% community-powered, meaning that bug fixes or new features
+                are implemented by volunteers but are not official.</p>
+            </div>
+        </div>
       </div>
 
       <div class="container">
@@ -45,7 +51,7 @@
                   <div class="center promo">
                     <i class="material-icons">flash_on</i>
                     <p class="promo-caption">Speeds up development</p>
-                    <p class="light center">We did most of the heavy lifting for you to provide a default stylings that incorporate our custom components. Additionally, we refined animations and transitions to provide a smoother experience for developers.</p>
+                    <p class="light center">Most of the heavy lifting is done for you to provide a default stylings that incorporate our custom components. We also refined animations and transitions to provide a smoother experience for developers.</p>
                   </div>
                 </div>
 

--- a/pug/page-contents/grid_content.html
+++ b/pug/page-contents/grid_content.html
@@ -211,8 +211,8 @@
               <div class="center promo promo-example">
                 <i class="material-icons">flash_on</i>
                 <p class="promo-caption">Speeds up development</p>
-                <p class="light center">We did most of the heavy lifting for you to provide a default stylings that incorporate our custom components.</p>
-              </div>
+                <p class="light center">Most of the heavy lifting is done for you to provide a default stylings that incorporate our custom components. We also refined animations and transitions to provide a smoother experience for developers.</p>
+                </div>
             </div>
             <div class="col s4">
               <div class="center promo promo-example">


### PR DESCRIPTION
## Proposed changes

- Added the community as part of the team, by explaining why we forked the repo and by adding a
dynamic image that show the top 24 contributors. Prob is that it don't sort by team members but
rather by commit numbers
- Added a message in the index page that says this version is a fork
- Changed the catchphrase in the homepage
- Rephrased a sentence inside the introduction grid shown in the homepage and grid section

fix #194

## Screenshots (if appropriate) or codepen:
<details>

<summary>Click here to see screenshots & changes:</summary>

![image](https://user-images.githubusercontent.com/28659185/139261883-6f435db9-f5ca-41db-84e1-955d3c3a66bc.png)
![image](https://user-images.githubusercontent.com/28659185/139261983-cff6e704-2413-4c94-9654-087398445444.png)

</details>

## Types of changes

- [x] Docs

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] (not needed) I have added tests to cover my changes.
- [x] All new and existing tests passed.
