### PR TITLE
docs(select): rephrase a sentence in select docs, issue 171

### DIFF
--- a/pug/page-contents/select_content.html
+++ b/pug/page-contents/select_content.html
@@ -158,8 +158,7 @@
 
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
-        <p>You must initialize the select element as shown below. In addition, you will need a separate call for any dynamically
-          generated select elements your page generates.</p>
+        <p>You must initialize the select element as shown below. In addition, you will need a separate call to init() for any dynamically generated select or any changes to an existing select.</p>
 
         <pre><code class="language-javascript">
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION

## Proposed changes

rephrase the sentence about the need to call init to reload a dynamic select component

fix #171

# screenshot

![](https://user-images.githubusercontent.com/28659185/139266640-dcebe501-7361-404e-999e-dd9a19e2af3b.png)

## Types of changes

docs

## Checklist

All fine