### PR TITLE
Refactored Select internaly for Arrays to prepare for other changes

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -80,12 +80,10 @@
         if (this.isMultiple) {
           // Multi-Select
           this._toggleEntryFromArray(value);
-          this._setValueToInput();
         } else {
           // Single-Select
           this._deselectAll();
           value.el.setAttribute('selected', 'selected');
-          this._setValueToInput();
         }
         const actualSelectedValues = this.getSelectedValues();
         const selectionHasChanged = !this._arraysEqual(

--- a/js/select.js
+++ b/js/select.js
@@ -255,9 +255,13 @@
       li.querySelector('input[type="checkbox"]').checked = !isSelected;
       return isSelected;
     }
+    _isOptionChosen(realOption) {
+      if (realOption.hasAttribute('disabled')) return false;
+      return realOption.selected || realOption.hasAttribute('selected');
+    }
     _setValueToInput() {
       const texts = this._values
-        .filter((value) => value.el.hasAttribute('selected') && !value.el.hasAttribute('disabled'))
+        .filter((value) => this._isOptionChosen(value.el))
         .map((value) => value.optionEl.querySelector('span').innerText.trim());
       // Set input-text to first Option with empty value which indicates a description like "choose your option"
       if (texts.length === 0) {
@@ -288,7 +292,7 @@
 
     getSelectedValues() {
       return this._values
-        .filter((value) => value.el.hasAttribute('selected') && !value.el.hasAttribute('disabled'))
+        .filter((value) => this._isOptionChosen(value.el))
         .map((value) => value.el.value);
     }
   }

--- a/js/select.js
+++ b/js/select.js
@@ -287,9 +287,9 @@
     }
 
     getSelectedValues() {
-      return this._values.filter(
-        (value) => value.el.hasAttribute('selected') && !value.el.hasAttribute('disabled')
-      );
+      return this._values
+        .filter((value) => value.el.hasAttribute('selected') && !value.el.hasAttribute('disabled'))
+        .map((value) => value.el.value);
     }
   }
 

--- a/js/select.js
+++ b/js/select.js
@@ -80,8 +80,11 @@
         } else {
           // Single-Select
           this._deselectAll();
-          value.el.setAttribute('selected', 'selected');
+          this._selectValue(value);
         }
+        // Refresh Input-Text
+        this._setValueToInput();
+        // Trigger Change-Event only when data is different
         const actualSelectedValues = this.getSelectedValues();
         const selectionHasChanged = !this._arraysEqual(
           previousSelectedValues,
@@ -166,6 +169,7 @@
       // Initialize dropdown
       if (!this.el.disabled) {
         let dropdownOptions = $.extend({}, this.options.dropdownOptions);
+        dropdownOptions.coverTrigger = false;
         let userOnOpenEnd = dropdownOptions.onOpenEnd;
         // Add callback for centering selected option when dropdown content is scrollable
         dropdownOptions.onOpenEnd = (el) => {
@@ -233,44 +237,41 @@
       $(this.dropdownOptions).append(li);
       return li;
     }
+
+    _selectValue(value) {
+      value.el.selected = true;
+      value.optionEl.classList.add('selected');
+      const checkbox = value.optionEl.querySelector('input[type="checkbox"]');
+      if (checkbox) checkbox.checked = true;
+    }
     _deselectValue(value) {
+      value.el.selected = false;
       value.optionEl.classList.remove('selected');
-      value.el.removeAttribute('selected');
+      const checkbox = value.optionEl.querySelector('input[type="checkbox"]');
+      if (checkbox) checkbox.checked = false;
     }
     _deselectAll() {
       this._values.forEach((value) => {
         this._deselectValue(value);
       });
     }
+    _isValueSelected(value) {
+      const realValues = this.getSelectedValues();
+      return realValues.some((realValue) => realValue === value.el.value);
+    }
     _toggleEntryFromArray(value) {
-      const li = value.optionEl;
-      const isSelected = li.classList.contains('selected');
-      if (isSelected) {
-        value.el.removeAttribute('selected');
-        li.classList.remove('selected');
-      } else {
-        value.el.setAttribute('selected', 'selected');
-        li.classList.add('selected');
-      }
-      li.querySelector('input[type="checkbox"]').checked = !isSelected;
-      return isSelected;
+      const isSelected = this._isValueSelected(value);
+      if (isSelected) this._deselectValue(value);
+      else this._selectValue(value);
     }
-    _isOptionChosen(realOption) {
-      if (realOption.hasAttribute('disabled')) return false;
-      return realOption.selected || realOption.hasAttribute('selected');
+    _getSelectedOptions() {
+      return Array.prototype.map.call(this.el.selectedOptions, (realOption) => realOption);
     }
+
     _setValueToInput() {
-      const texts = this._values
-        .filter((value) => this._isOptionChosen(value.el))
-        .map((value) => value.optionEl.querySelector('span').innerText.trim());
-      // Set input-text to first Option with empty value which indicates a description like "choose your option"
-      if (texts.length === 0) {
-        const firstDisabledOption = this.$el.find('option:disabled').eq(0);
-        if (firstDisabledOption.length > 0 && firstDisabledOption[0].value === '') {
-          this.input.value = firstDisabledOption.text();
-          return;
-        }
-      }
+      const realOptions = this._getSelectedOptions();
+      const values = this._values.filter((value) => realOptions.indexOf(value.el) >= 0);
+      const texts = values.map((value) => value.optionEl.querySelector('span').innerText.trim());
       this.input.value = texts.join(', ');
     }
     _setSelectedStates() {
@@ -291,9 +292,7 @@
     }
 
     getSelectedValues() {
-      return this._values
-        .filter((value) => this._isOptionChosen(value.el))
-        .map((value) => value.el.value);
+      return this._getSelectedOptions().map((realOption) => realOption.value);
     }
   }
 

--- a/js/select.js
+++ b/js/select.js
@@ -6,72 +6,36 @@
     dropdownOptions: {}
   };
 
-  /**
-   * @class
-   *
-   */
   class FormSelect extends Component {
-    /**
-     * Construct FormSelect instance
-     * @constructor
-     * @param {Element} el
-     * @param {Object} options
-     */
     constructor(el, options) {
       super(FormSelect, el, options);
-
-      // Don't init if browser default version
-      if (this.$el.hasClass('browser-default')) {
-        return;
-      }
-
+      if (this.$el.hasClass('browser-default')) return;
       this.el.M_FormSelect = this;
-
-      /**
-       * Options for the select
-       * @member FormSelect#options
-       */
       this.options = $.extend({}, FormSelect.defaults, options);
-
       this.isMultiple = this.$el.prop('multiple');
-
-      // Setup
       this.el.tabIndex = -1;
-      this._keysSelected = {};
-      this._valueDict = {}; // Maps key to original and generated option element.
-      this._setupDropdown();
 
+      this._selectedValues = [];
+      this._values = [];
+
+      this._setupDropdown();
       this._setupEventHandlers();
     }
-
     static get defaults() {
       return _defaults;
     }
-
     static init(els, options) {
       return super.init(this, els, options);
     }
-
-    /**
-     * Get Instance
-     */
     static getInstance(el) {
       let domElem = !!el.jquery ? el[0] : el;
       return domElem.M_FormSelect;
     }
-
-    /**
-     * Teardown component
-     */
     destroy() {
       this._removeEventHandlers();
       this._removeDropdown();
       this.el.M_FormSelect = undefined;
     }
-
-    /**
-     * Setup Event Handlers
-     */
     _setupEventHandlers() {
       this._handleSelectChangeBound = this._handleSelectChange.bind(this);
       this._handleOptionClickBound = this._handleOptionClick.bind(this);
@@ -85,10 +49,6 @@
       this.el.addEventListener('change', this._handleSelectChangeBound);
       this.input.addEventListener('click', this._handleInputClickBound);
     }
-
-    /**
-     * Remove Event Handlers
-     */
     _removeEventHandlers() {
       $(this.dropdownOptions)
         .find('li:not(.optgroup)')
@@ -98,66 +58,50 @@
       this.el.removeEventListener('change', this._handleSelectChangeBound);
       this.input.removeEventListener('click', this._handleInputClickBound);
     }
-
-    /**
-     * Handle Select Change
-     * @param {Event} e
-     */
     _handleSelectChange(e) {
       this._setValueToInput();
     }
-
-    /**
-     * Handle Option Click
-     * @param {Event} e
-     */
     _handleOptionClick(e) {
       e.preventDefault();
       let optionEl = $(e.target).closest('li')[0];
-      this._selectOption(optionEl);
+      this._selectOptionElement(optionEl);
       e.stopPropagation();
     }
 
-    _selectOption(optionEl) {
+    _selectOptionElement(optionEl) {
       let key = optionEl.id;
       if (!$(optionEl).hasClass('disabled') && !$(optionEl).hasClass('optgroup') && key.length) {
-        let selected = true;
-
+        // let selected = true;
         if (this.isMultiple) {
           // Deselect placeholder option if still selected.
-          let placeholderOption = $(this.dropdownOptions).find('li.disabled.selected');
-          if (placeholderOption.length) {
-            placeholderOption.removeClass('selected');
-            placeholderOption.find('input[type="checkbox"]').prop('checked', false);
-            this._toggleEntryFromArray(placeholderOption[0].id);
-          }
-          selected = this._toggleEntryFromArray(key);
+          // let placeholderOption = $(this.dropdownOptions).find('li.disabled.selected');
+          // if (placeholderOption.length) {
+          //   placeholderOption.removeClass('selected');
+          //   placeholderOption.find('input[type="checkbox"]').prop('checked', false);
+          //   this._toggleEntryFromArray(placeholderOption[0].id);
+          // }
+          // selected =
+          this._toggleEntryFromArray(key);
         } else {
+          // Single-Select
           $(this.dropdownOptions)
             .find('li')
             .removeClass('selected');
           $(optionEl).toggleClass('selected', selected);
-          this._keysSelected = {};
-          this._keysSelected[optionEl.id] = true;
+          this._selectedValues = [];
+          this._selectedValues.push(optionEl);
         }
-
         // Set selected on original select option
         // Only trigger if selected state changed
-        let prevSelected = $(this._valueDict[key].el).prop('selected');
-        if (prevSelected !== selected) {
-          $(this._valueDict[key].el).prop('selected', selected);
-          this.$el.trigger('change');
-        }
+        // let prevSelected = $(this._values[key].el).prop('selected');
+        // if (prevSelected !== selected) {
+        //   $(this._values[key].el).prop('selected', selected);
+        //   this.$el.trigger('change');
+        // }
       }
-
-      if (!this.isMultiple) {
-        this.dropdown.close();
-      }
+      if (!this.isMultiple) this.dropdown.close();
     }
 
-    /**
-     * Handle Input Click
-     */
     _handleInputClick() {
       if (this.dropdown && this.dropdown.isOpen) {
         this._setValueToInput();
@@ -165,21 +109,17 @@
       }
     }
 
-    /**
-     * Setup dropdown
-     */
     _setupDropdown() {
       this.wrapper = document.createElement('div');
       $(this.wrapper).addClass('select-wrapper ' + this.options.classes);
       this.$el.before($(this.wrapper));
+
       // Move actual select element into overflow hidden wrapper
       let $hideSelect = $('<div class="hide-select"></div>');
       $(this.wrapper).append($hideSelect);
       $hideSelect[0].appendChild(this.el);
 
-      if (this.el.disabled) {
-        this.wrapper.classList.add('disabled');
-      }
+      if (this.el.disabled) this.wrapper.classList.add('disabled');
 
       // Create dropdown
       this.$selectOptions = this.$el.children('option, optgroup');
@@ -189,34 +129,26 @@
         'dropdown-content select-dropdown ' + (this.isMultiple ? 'multiple-select-dropdown' : '')
       );
 
-      // Create dropdown structure.
+      // Create dropdown structure
       if (this.$selectOptions.length) {
         this.$selectOptions.each((el) => {
           if ($(el).is('option')) {
-            // Direct descendant option.
-            let optionEl;
-            if (this.isMultiple) {
-              optionEl = this._appendOptionWithIcon(this.$el, el, 'multiple');
-            } else {
-              optionEl = this._appendOptionWithIcon(this.$el, el);
-            }
-
-            this._addOptionToValueDict(el, optionEl);
+            // Direct descendant option
+            const option = this._createOptionWithIcon(el, this.isMultiple ? 'multiple' : undefined);
+            this._addOptionToValues(el, option);
           } else if ($(el).is('optgroup')) {
-            // Optgroup.
+            // Optgroup
             let selectOptions = $(el).children('option');
             $(this.dropdownOptions).append(
               $('<li class="optgroup"><span>' + el.getAttribute('label') + '</span></li>')[0]
             );
-
             selectOptions.each((el) => {
-              let optionEl = this._appendOptionWithIcon(this.$el, el, 'optgroup-option');
-              this._addOptionToValueDict(el, optionEl);
+              const option = this._createOptionWithIcon(el, 'optgroup-option');
+              this._addOptionToValues(el, option);
             });
           }
         });
       }
-
       $(this.wrapper).append(this.dropdownOptions);
 
       // Add input dropdown
@@ -225,9 +157,7 @@
       this.input.setAttribute('type', 'text');
       this.input.setAttribute('readonly', 'true');
       this.input.setAttribute('data-target', this.dropdownOptions.id);
-      if (this.el.disabled) {
-        $(this.input).prop('disabled', 'true');
-      }
+      if (this.el.disabled) $(this.input).prop('disabled', 'true');
 
       $(this.wrapper).prepend(this.input);
       this._setValueToInput();
@@ -237,25 +167,21 @@
         '<svg class="caret" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
       );
       $(this.wrapper).prepend(dropdownIcon[0]);
-
       // Initialize dropdown
       if (!this.el.disabled) {
         let dropdownOptions = $.extend({}, this.options.dropdownOptions);
         let userOnOpenEnd = dropdownOptions.onOpenEnd;
-
         // Add callback for centering selected option when dropdown content is scrollable
         dropdownOptions.onOpenEnd = (el) => {
           let selectedOption = $(this.dropdownOptions)
             .find('.selected')
             .first();
-
           if (selectedOption.length) {
             // Focus selected option in dropdown
             M.keyDown = true;
             this.dropdown.focusedIndex = selectedOption.index();
             this.dropdown._focusFocusedItem();
             M.keyDown = false;
-
             // Handle scrolling to selected option
             if (this.dropdown.isScrollable) {
               let scrollOffset =
@@ -265,42 +191,25 @@
               this.dropdownOptions.scrollTop = scrollOffset;
             }
           }
-
           // Handle user declared onOpenEnd if needed
-          if (userOnOpenEnd && typeof userOnOpenEnd === 'function') {
+          if (userOnOpenEnd && typeof userOnOpenEnd === 'function')
             userOnOpenEnd.call(this.dropdown, this.el);
-          }
         };
-
         // Prevent dropdown from closing too early
         dropdownOptions.closeOnClick = false;
-
         this.dropdown = M.Dropdown.init(this.input, dropdownOptions);
       }
-
       // Add initial selections
       this._setSelectedStates();
     }
 
-    /**
-     * Add option to value dict
-     * @param {Element} el  original option element
-     * @param {Element} optionEl  generated option element
-     */
-    _addOptionToValueDict(el, optionEl) {
-      let index = Object.keys(this._valueDict).length;
+    _addOptionToValues(el, optionEl) {
+      let index = this._values.length;
       let key = this.dropdownOptions.id + index;
-      let obj = {};
       optionEl.id = key;
-
-      obj.el = el;
-      obj.optionEl = optionEl;
-      this._valueDict[key] = obj;
+      this._values.push({ el, optionEl });
     }
 
-    /**
-     * Remove dropdown
-     */
     _removeDropdown() {
       $(this.wrapper)
         .find('.caret')
@@ -311,141 +220,91 @@
       $(this.wrapper).remove();
     }
 
-    /**
-     * Setup dropdown
-     * @param {Element} select  select element
-     * @param {Element} option  option element from select
-     * @param {String} type
-     * @return {Element}  option element added
-     */
-    _appendOptionWithIcon(select, option, type) {
-      // Add disabled attr if disabled
+    _createOptionWithIcon(option, type) {
       let disabledClass = option.disabled ? 'disabled ' : '';
       let optgroupClass = type === 'optgroup-option' ? 'optgroup-option ' : '';
       let multipleCheckbox = this.isMultiple
         ? `<label><input type="checkbox"${disabledClass}"/><span>${option.innerHTML}</span></label>`
         : option.innerHTML;
-      let liEl = $('<li></li>');
-      let spanEl = $('<span></span>');
-      spanEl.html(multipleCheckbox);
-      liEl.addClass(`${disabledClass} ${optgroupClass}`);
-      liEl.append(spanEl);
-
+      let li = $('<li></li>');
+      let span = $('<span></span>');
+      span.html(multipleCheckbox);
+      li.addClass(`${disabledClass} ${optgroupClass}`);
+      li.append(span);
       // add icons
       let iconUrl = option.getAttribute('data-icon');
       let classes = option.getAttribute('class');
-      if (!!iconUrl) {
-        let imgEl = $(`<img alt="" class="${classes}" src="${iconUrl}">`);
-        liEl.prepend(imgEl);
+      if (iconUrl) {
+        const img = $(`<img alt="" class="${classes}" src="${iconUrl}">`);
+        li.prepend(img);
       }
-
       // Check for multiple type.
-      $(this.dropdownOptions).append(liEl[0]);
-      return liEl[0];
+      $(this.dropdownOptions).append(li[0]);
+      return li[0];
     }
 
-    /**
-     * Toggle entry from option
-     * @param {String} key  Option key
-     * @return {Boolean}  if entry was added or removed
-     */
     _toggleEntryFromArray(key) {
-      let notAdded = !this._keysSelected.hasOwnProperty(key);
-      let $optionLi = $(this._valueDict[key].optionEl);
-
-      if (notAdded) {
-        this._keysSelected[key] = true;
+      const li = this._values.filter((value) => value.optionEl.id === key)[0];
+      const isNotSelected =
+        this._selectedValues.filter((value) => value.optionEl.id === key).length === 0;
+      if (isNotSelected) {
+        this._selectedValues.push(li);
       } else {
-        delete this._keysSelected[key];
+        this._selectedValues = this._selectedValues.filter((value) => value.optionEl.id !== key);
       }
-
-      $optionLi.toggleClass('selected', notAdded);
-
-      // Set checkbox checked value
-      $optionLi.find('input[type="checkbox"]').prop('checked', notAdded);
-
+      li.toggleClass('selected', isNotSelected);
+      li.find('input[type="checkbox"]').prop('checked', isNotSelected);
       // use notAdded instead of true (to detect if the option is selected or not)
-      $optionLi.prop('selected', notAdded);
-
-      return notAdded;
+      li.prop('selected', isNotSelected);
+      return isNotSelected;
     }
 
-    /**
-     * Set text value to input
-     */
     _setValueToInput() {
       let values = [];
       let options = this.$el.find('option');
-
       options.each((el) => {
         if ($(el).prop('selected')) {
-          let text = $(el).text().trim();
+          let text = $(el)
+            .text()
+            .trim();
           values.push(text);
         }
       });
-
       if (!values.length) {
         let firstDisabled = this.$el.find('option:disabled').eq(0);
-        if (firstDisabled.length && firstDisabled[0].value === '') {
+        if (firstDisabled.length && firstDisabled[0].value === '')
           values.push(firstDisabled.text());
-        }
       }
-
       this.input.value = values.join(', ');
     }
 
-    /**
-     * Set selected state of dropdown to match actual select element
-     */
     _setSelectedStates() {
-      this._keysSelected = {};
-
-      for (let key in this._valueDict) {
-        let option = this._valueDict[key];
-        let optionIsSelected = $(option.el).prop('selected');
+      this._selectedValues = [];
+      this._values.forEach((option) => {
+        const optionIsSelected = $(option.el).prop('selected');
         $(option.optionEl)
           .find('input[type="checkbox"]')
           .prop('checked', optionIsSelected);
         if (optionIsSelected) {
           this._activateOption($(this.dropdownOptions), $(option.optionEl));
-          this._keysSelected[key] = true;
-        } else {
-          $(option.optionEl).removeClass('selected');
-        }
-      }
+          this._selectedValues.push(option);
+        } else $(option.optionEl).removeClass('selected');
+      });
     }
 
-    /**
-     * Make option as selected and scroll to selected position
-     * @param {jQuery} collection  Select options jQuery element
-     * @param {Element} newOption  element of the new option
-     */
+    // Make option as selected and scroll to selected position
     _activateOption(collection, newOption) {
-      if (newOption) {
-        if (!this.isMultiple) {
-          collection.find('li.selected').removeClass('selected');
-        }
-        let option = $(newOption);
-        option.addClass('selected');
-      }
+      if (!newOption) return;
+      if (!this.isMultiple) collection.find('li.selected').removeClass('selected');
+      $(newOption).addClass('selected');
     }
 
-    /**
-     * Get Selected Values
-     * @return {Array}  Array of selected values
-     */
     getSelectedValues() {
-      let selectedValues = [];
-      for (let key in this._keysSelected) {
-        selectedValues.push(this._valueDict[key].el.value);
-      }
-      return selectedValues;
+      return this._selectedValues;
     }
   }
 
   M.FormSelect = FormSelect;
 
-  if (M.jQueryLoaded) {
-    M.initializeJqueryWrapper(FormSelect, 'formSelect', 'M_FormSelect');
-  }
+  if (M.jQueryLoaded) M.initializeJqueryWrapper(FormSelect, 'formSelect', 'M_FormSelect');
 })(cash);

--- a/js/select.js
+++ b/js/select.js
@@ -265,13 +265,21 @@
       else this._selectValue(value);
     }
     _getSelectedOptions() {
-      return Array.prototype.map.call(this.el.selectedOptions, (realOption) => realOption);
+      return Array.prototype.filter.call(this.el.selectedOptions, (realOption) => realOption);
     }
 
     _setValueToInput() {
       const realOptions = this._getSelectedOptions();
       const values = this._values.filter((value) => realOptions.indexOf(value.el) >= 0);
       const texts = values.map((value) => value.optionEl.querySelector('span').innerText.trim());
+      // Set input-text to first Option with empty value which indicates a description like "choose your option"
+      if (texts.length === 0) {
+        const firstDisabledOption = this.$el.find('option:disabled').eq(0);
+        if (firstDisabledOption.length > 0 && firstDisabledOption[0].value === '') {
+          this.input.value = firstDisabledOption.text();
+          return;
+        }
+      }
       this.input.value = texts.join(', ');
     }
     _setSelectedStates() {

--- a/js/select.js
+++ b/js/select.js
@@ -57,14 +57,12 @@
     _handleSelectChange(e) {
       this._setValueToInput();
     }
-
     _handleOptionClick(e) {
       e.preventDefault();
       let virtualOption = $(e.target).closest('li')[0];
       this._selectOptionElement(virtualOption);
       e.stopPropagation();
     }
-
     _arraysEqual(a, b) {
       if (a === b) return true;
       if (a == null || b == null) return false;
@@ -72,7 +70,6 @@
       for (let i = 0; i < a.length; ++i) if (a[i] !== b[i]) return false;
       return true;
     }
-
     _selectOptionElement(virtualOption) {
       if (!$(virtualOption).hasClass('disabled') && !$(virtualOption).hasClass('optgroup')) {
         const value = this._values.filter((value) => value.optionEl === virtualOption)[0];
@@ -94,14 +91,12 @@
       }
       if (!this.isMultiple) this.dropdown.close();
     }
-
     _handleInputClick() {
       if (this.dropdown && this.dropdown.isOpen) {
         this._setValueToInput();
         this._setSelectedStates();
       }
     }
-
     _setupDropdown() {
       this.wrapper = document.createElement('div');
       $(this.wrapper).addClass('select-wrapper ' + this.options.classes);
@@ -203,11 +198,9 @@
       // Add initial selections
       this._setSelectedStates();
     }
-
     _addOptionToValues(realOption, virtualOption) {
       this._values.push({ el: realOption, optionEl: virtualOption });
     }
-
     _removeDropdown() {
       $(this.wrapper)
         .find('.caret')
@@ -217,7 +210,6 @@
       $(this.wrapper).before(this.$el);
       $(this.wrapper).remove();
     }
-
     _createAndAppendOptionWithIcon(realOption, type) {
       const li = document.createElement('li');
       if (realOption.disabled) li.classList.add('disabled');
@@ -241,7 +233,6 @@
       $(this.dropdownOptions).append(li);
       return li;
     }
-
     _deselectValue(value) {
       value.optionEl.classList.remove('selected');
       value.el.removeAttribute('selected');
@@ -294,6 +285,7 @@
       if (!this.isMultiple) ul.find('li.selected').removeClass('selected');
       $(li).addClass('selected');
     }
+
     getSelectedValues() {
       return this._values.filter(
         (value) => value.el.hasAttribute('selected') && !value.el.hasAttribute('disabled')

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -109,10 +109,10 @@
         });
         // Methods
         document.querySelector('.btn1').addEventListener('click', e => {
-          alert(instances[0].getSelectedValues().map(value => value.el.value));
+          alert(instances[0].getSelectedValues());
         });
         document.querySelector('.btn2').addEventListener('click', e => {
-          alert(instances[1].getSelectedValues().map(value => value.el.value));
+          alert(instances[1].getSelectedValues());
         });
       });
     </script>

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -18,30 +18,31 @@
   </head>
   <body>
 
-    <div class="input-field col s12">
-      <select>
-        <option value="" disabled selected>Choose your option</option>
-        <option value="1">Option 1</option>
-        <option value="2">Option 2</option>
-        <option value="3">Option 3</option>
-      </select>
-      <label>Single-Select</label>
+    <div class="row">
+      <div class="input-field col s12 m6">
+        <select>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+        <label>Single-Select</label>
+        <div>
+          <button class="btn1">Get Single-Select Values</button>
+        </div>
+      </div>
+      <div class="input-field col s12 m6">
+        <select multiple>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+        <label>Multi-Select</label>
+        <div>
+          <button class="btn2">Get Multi-Select Values</button>
+        </div>
+      </div>
     </div>
 
-    <div class="input-field col s12">
-      <select multiple>
-        <option value="" disabled selected>Choose your option</option>
-        <option value="1">Option 1</option>
-        <option value="2">Option 2</option>
-        <option value="3">Option 3</option>
-      </select>
-      <label>Multi-Select</label>
-    </div>
-
-    <div class="input-field col s12">
-      <button class="btn1">Get Single-Select Values</button>
-      <button class="btn2">Get Multi-Select Values</button>
-    </div>
 
     <div class="input-field col s12">
       <select>
@@ -116,13 +117,27 @@
       </div>
     </div>
 
-    <label>Browser Select</label>
-    <select class="browser-default">
-      <option value="" disabled selected>Choose your option</option>
-      <option value="1">Option 1</option>
-      <option value="2">Option 2</option>
-      <option value="3">Option 3</option>
-    </select>
+    <div class="row">
+      <div class="col s12 m6">
+        <label>Browser Single-Select</label>
+        <select class="browser-default">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+      </div>
+      <div class="col s12 m6">
+        <label>Browser Multi-Select</label>
+        <select class="browser-default" multiple style="height:150px;">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+      </div>
+    </div>
+
 
 
     <script src="../../../bin/materialize.js"></script>

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -39,6 +39,11 @@
     </div>
 
     <div class="input-field col s12">
+      <button class="btn1">Get Single-Select Values</button>
+      <button class="btn2">Get Multi-Select Values</button>
+    </div>
+
+    <div class="input-field col s12">
       <select>
         <optgroup label="team 1">
           <option value="1">Option 1</option>
@@ -52,35 +57,63 @@
       <label>Single-Select with Optgroups</label>
     </div>
 
-    <div class="input-field col s12 m6">
-      <select class="icons">
-        <option value="" disabled selected>Choose your option</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
-      </select>
-      <label>Single-Select with Images (right)</label>
+    <div class="row">
+      <h5>Selects with Images</h5>
+      <div class="input-field col s12 m6">
+        <select class="icons">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
+        </select>
+        <label>Single-Select with Images (right)</label>
+      </div>  
+      <div class="input-field col s12 m6">
+        <select class="icons">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_a.png" class="left">example 1</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_b.png" class="left">example 2</option>
+          <option value="" data-icon="../../docs/images/placeholder/250x250_c.png" class="left">example 3</option>
+        </select>
+        <label>Single-Select with Images (left)</label>
+      </div>
     </div>
 
-    <div class="input-field col s12 m6">
-      <select class="icons">
-        <option value="" disabled selected>Choose your option</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_a.png" class="left">example 1</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_b.png" class="left">example 2</option>
-        <option value="" data-icon="../../docs/images/placeholder/250x250_c.png" class="left">example 3</option>
-      </select>
-      <label>Single-Select with Images (left)</label>
+    <div class="row">
+      <h5>Select with selected Options</h5>
+      <div class="input-field col s12 m6">
+        <select>
+          <option value="" disabled>Choose your option</option>
+          <option value="1">Option 1</option>
+          <option value="2" selected>Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+        <label>Single-Select with Value set</label>
+      </div>
+      <div class="input-field col s12 m6">
+        <select multiple class="icons">
+          <option value="" disabled selected>Choose your option</option>
+          <option value="1" selected data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
+          <option value="2" selected data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
+          <option value="3" disabled data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
+          <option value="4" selected disabled data-icon="../../docs/images/placeholder/250x250_d.png">example 3</option>
+          <option value="5" data-icon="../../docs/images/placeholder/250x250_e.png">example 4</option>
+          <option value="6">example 5</option>
+        </select>
+        <label>Multi-Select with Images (right) and Pre-Selections</label>
+      </div>
     </div>
 
-    <div class="input-field col s12 m6">
-      <select multiple class="icons">
-        <option value="" disabled selected>Choose your option</option>
-        <option value="1" selected data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
-        <option value="2" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
-        <option value="3" disabled data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
-        <option value="4" selected disabled data-icon="../../docs/images/placeholder/250x250_d.png">example 3</option>
-      </select>
-      <label>Multi-Select with Images (right) and Pre-Selections</label>
+    <div class="row">
+      <h5>Dynamically generated Select-Options <button class="btn3">Create + Init Select</button></h5>
+      <div class="input-field col s12 m6">
+        <select class="dynamic-select-single"></select>
+        <label>Dynamic Single-Select</label>
+      </div>
+      <div class="input-field col s12 m6">
+        <select class="dynamic-select-multi" multiple></select>
+        <label>Dynamic Multi-Select</label>
+      </div>
     </div>
 
     <label>Browser Select</label>
@@ -91,10 +124,6 @@
       <option value="3">Option 3</option>
     </select>
 
-    <div style="margin-top:3em;">
-      <button class="btn1">First Single-Select Values</button>
-      <button class="btn2">First Multi-Select Values</button>
-    </div>
 
     <script src="../../../bin/materialize.js"></script>
     <script type="text/javascript">
@@ -113,7 +142,38 @@
         });
         document.querySelector('.btn2').addEventListener('click', e => {
           alert(instances[1].getSelectedValues());
+        });        
+        document.querySelector('.btn3').addEventListener('click', e => {
+          const optionIndexes = [1,2,3,4,5,6];
+          // Single-Select
+          const singleSelect = document.querySelector('.dynamic-select-single');
+          singleSelect.innerHTML = '';
+          optionIndexes.map(index => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.innerText = 'option '+index;
+            const isSelected = index === 3;
+            // Set via Attribute
+            if (isSelected)
+              option.setAttribute('selected', 'selected');
+            singleSelect.appendChild(option);
+          });
+          // Multi-Select
+          const multiSelect = document.querySelector('.dynamic-select-multi');
+          multiSelect.innerHTML = '';
+          optionIndexes.map(index => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.innerText = 'option '+index;
+            // Set directly (all even options)
+            option.selected = index % 2 === 0;
+            multiSelect.appendChild(option);
+          });
+          // Init both
+          M.FormSelect.init(singleSelect, {});
+          M.FormSelect.init(multiSelect, {});
         });
+
       });
     </script>
   </body>

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -103,7 +103,7 @@
 
         elems[0].addEventListener('change', e => console.log("First Select changed!"));
         elems[1].addEventListener('change', e => console.log("Second Select changed!"));
-        
+
         var instances = M.FormSelect.init(elems, {
           // specify options here
         });

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -21,6 +21,7 @@
     <div class="row">
       <div class="input-field col s12 m6">
         <select>
+          <option value="" disabled selected>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
@@ -32,6 +33,7 @@
       </div>
       <div class="input-field col s12 m6">
         <select multiple>
+          <option value="" disabled>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -25,7 +25,7 @@
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
       </select>
-      <label>Materialize Select</label>
+      <label>Single-Select</label>
     </div>
 
     <div class="input-field col s12">
@@ -35,7 +35,7 @@
         <option value="2">Option 2</option>
         <option value="3">Option 3</option>
       </select>
-      <label>Materialize Multiple Select</label>
+      <label>Multi-Select</label>
     </div>
 
     <div class="input-field col s12">
@@ -49,7 +49,7 @@
           <option value="4">Option 4</option>
         </optgroup>
       </select>
-      <label>Optgroups</label>
+      <label>Single-Select with Optgroups</label>
     </div>
 
     <div class="input-field col s12 m6">
@@ -59,8 +59,9 @@
         <option value="" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
         <option value="" data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
       </select>
-      <label>Images in select</label>
+      <label>Single-Select with Images (right)</label>
     </div>
+
     <div class="input-field col s12 m6">
       <select class="icons">
         <option value="" disabled selected>Choose your option</option>
@@ -68,7 +69,18 @@
         <option value="" data-icon="../../docs/images/placeholder/250x250_b.png" class="left">example 2</option>
         <option value="" data-icon="../../docs/images/placeholder/250x250_c.png" class="left">example 3</option>
       </select>
-      <label>Images in select</label>
+      <label>Single-Select with Images (left)</label>
+    </div>
+
+    <div class="input-field col s12 m6">
+      <select multiple class="icons">
+        <option value="" disabled selected>Choose your option</option>
+        <option value="1" selected data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
+        <option value="2" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
+        <option value="3" disabled data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
+        <option value="4" selected disabled data-icon="../../docs/images/placeholder/250x250_d.png">example 3</option>
+      </select>
+      <label>Multi-Select with Images (right) and Pre-Selections</label>
     </div>
 
     <label>Browser Select</label>
@@ -79,16 +91,30 @@
       <option value="3">Option 3</option>
     </select>
 
+    <div style="margin-top:3em;">
+      <button class="btn1">First Single-Select Values</button>
+      <button class="btn2">First Multi-Select Values</button>
+    </div>
 
     <script src="../../../bin/materialize.js"></script>
-
     <script type="text/javascript">
-    document.addEventListener('DOMContentLoaded', function() {
-      var elems = document.querySelectorAll('select');
-      var instances = M.FormSelect.init(elems, {
-        // specify options here
+      document.addEventListener('DOMContentLoaded', function() {
+        var elems = document.querySelectorAll('select');
+
+        elems[0].addEventListener('change', e => console.log("First Select changed!"));
+        elems[1].addEventListener('change', e => console.log("Second Select changed!"));
+        
+        var instances = M.FormSelect.init(elems, {
+          // specify options here
+        });
+        // Methods
+        document.querySelector('.btn1').addEventListener('click', e => {
+          alert(instances[0].getSelectedValues().map(value => value.el.value));
+        });
+        document.querySelector('.btn2').addEventListener('click', e => {
+          alert(instances[1].getSelectedValues().map(value => value.el.value));
+        });
       });
-    });
     </script>
   </body>
 </html>


### PR DESCRIPTION
I improved the internal structure of the component, because I saw that there where no Array used for the Options.
So there are no visible changes for the users, but the code is working now internally better and faster.
This is the preperation of dynamically loading Options without reinitializing the Component. But I also thougt
about making the Select similiar to the Autocomplete and give a "data" Object which can then be rendered.

**Future Plan:**
This should also be done in the Autocomplete. In the Autocomplete it will be a breaking change.
I want to make a combination of the Autocomplete and the Multi-Select with dynamic Loading Data
because I need it for my own Project, but I saw that it was already multiple times requested by other users.

For Reference see issues here:
#219 
#67
#115
#171
#124

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
