### PR TITLE
Add maintainers doc

### DIFF
--- a/FOR_MAINTAINERS.md
+++ b/FOR_MAINTAINERS.md
@@ -1,0 +1,65 @@
+# For Maintainers
+This is the documentation that will be used by the maintainers. If you have any better idea on how to do things better, please let us know by creating an issue or PR 😉.
+
+- [Labels](#labels)
+- [Releasing a new version](#releasing-a-new-version)
+- [Generating CHANGELOG.md](#generating-changelogmd)
+
+## Labels
+We have several labels that we can use to organize the issues and PRs on this repo, and also to make the changelog generation easier. All the labels and their descriptions can be [read here](https://github.com/materializecss/materialize/issues/labels).
+
+But there are important labels that are related to [changelog generation](#generating-changelogmd), which will determine where all the merged PRs end up. Any other PRs that hasn't labeled with one of these will not be shown on the changelog. Please take a look at the table below
+
+| Label         | Section                  |
+|---------------|--------------------------|
+| enhancement   | Implemented enhancements |
+| bug           | Fixed bugs               |
+| documentation | Documentation changes    |
+| meta          | Meta changes             |
+
+## Releasing a new version
+To fully release a new version, you need to have access to the @materializecss organization on the npmjs. Then, please follow the steps below:
+1. Run `npm run release -- --oldver=<current_version> --newver=<new_version>`
+   > What this command does is that it will replace any occurrences of "<current_version>" with the "<new_version>". So for example, if the current release is `1.0.0`, and then the planned release is `1.1.0`, the command is
+   > ```
+   > npm run release -- --oldver=1.0.0 --newver=1.1.0
+   > ```
+2. Verify that version in package.json is correctly replaced
+3. [Then generate the CHANGELOG.md](#generating-changelogmd)
+4. Create a PR ([example](https://github.com/materializecss/materialize/pull/258) so that we can verify nothing goes wrong, address the feedback from the reviewers if there is any
+5. Merge the PR after most (hopefully everyone) happy with the planned release PR
+6. Create a new release on GitHub
+   * With release notes from the generated CHANGELOG.md
+   * Upload the `materialize-v<new_vversion>.zip` from the bin folder
+   * Don't forget to create a new tag together with the release
+7. Publish the release on npmjs
+   * If you never logged in on npm, please do `npm login` first and enter your credentials
+   * Then run `npm publish` and follow the instructions there
+8. Done! Yay new version 🥳
+
+## Generating CHANGELOG.md
+To generate the CHANGELOG.md, we will use [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) to automatically generate it. The changelog will be generated based on merged PRs. So if you have any changes that need to be mentioned on release notes, please avoid commit it directly to the main branch, and do create a PR for it.
+
+Also it's important that if you want to merge the PR, **please use "merge and commit", do not squash**. Because for some reason the generator can't recognize the squashed PRs.
+
+> I think this is noteworthy to mention it on their repo, maybe also fix it?
+
+To make it easier, you can use Docker to run it. You can use the command below to get started.
+
+```
+docker run -it --rm \
+  -v "$(pwd)":/usr/local/src/your-app \
+  githubchangeloggenerator/github-changelog-generator \
+  -u materializecss \
+  -p materialize \
+  --base dontusehistorypls.md \
+  --since-tag 1.0.0 \
+  --token <your_GitHub_token> \
+  --no-issues \
+  --future-release 1.1.0 \
+  --bug-labels bug,bugfix \
+  --breaking-labels "breaking changes" \
+  --add-section '{"docs":{"labels":["documentation"],"prefix":"**Documentation changes:**"},"meta":{"labels":["build","meta"],"prefix":"**Meta changes:**"}}'
+```
+
+Btw, the `--token` param is optional. But since GitHub API has rate limitations for unauthenticated requests, I recommend you to use the token. [You can follow the instructions from their repo.](https://github.com/github-changelog-generator/github-changelog-generator#github-token)

--- a/FOR_MAINTAINERS.md
+++ b/FOR_MAINTAINERS.md
@@ -24,7 +24,10 @@ To fully release a new version, you need to have access to the @materializecss o
    > ```
    > npm run release -- --oldver=1.0.0 --newver=1.1.0
    > ```
-2. Verify that version in package.json is correctly replaced
+2. Verify that version is correctly replaced in:
+   * package.json
+   * js\global.js
+   * the docs correctly shown the new version
 3. [Then generate the CHANGELOG.md](#generating-changelogmd)
 4. Create a PR ([example](https://github.com/materializecss/materialize/pull/258) so that we can verify nothing goes wrong, address the feedback from the reviewers if there is any
 5. Merge the PR after most (hopefully everyone) happy with the planned release PR


### PR DESCRIPTION
## Proposed changes
In this PR, I would like to propose a documentation for the maintainers. So that if I'm not available and/or someone else would like to move this forward in the future, at least we will know what should be done.

In this document, I added 3 sections, which is labels, releasing a new version, and generating a changelog.

Let me know what do you think about this.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
