### PR TITLE
Fix `striped` for tables. Fixes #279.

### DIFF
--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -398,6 +398,12 @@ table {
     tr {
       border-bottom: none;
     }
+
+    > tbody {
+      > tr:nth-child(odd) {
+        background-color: $table-striped-color;
+      }
+    }
   }
 
   &.highlight > tbody > tr {

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -399,10 +399,8 @@ table {
       border-bottom: none;
     }
 
-    > tbody {
-      > tr:nth-child(odd) {
-        background-color: $table-striped-color;
-      }
+    > tbody > tr:nth-child(odd) {
+      background-color: $table-striped-color;
     }
   }
 


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Makes `striped` work for tables again, which is a fix for #279. Bug is described within the issue.

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
