### PR TITLE
fix: floating labels do not work when type attribute is absent from input element #288

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -1,5 +1,6 @@
 (function($) {
   const TEXT_BASED_INPUT_SELECTOR = [
+    'input:not([type])',
     'input[type=text]',
     'input[type=password]',
     'input[type=email]',

--- a/tests/spec/forms/formsFixture.html
+++ b/tests/spec/forms/formsFixture.html
@@ -3,6 +3,10 @@
   <input id="text-input" type="text" />
 </div>
 <div class="input-field">
+  <label for="no-type-attribute">no type attribute</label>
+  <input id="no-type-attribute" />
+</div>
+<div class="input-field">
   <label for="password-input">password</label>
   <input id="password-input" type="password" />
 </div>


### PR DESCRIPTION
## Proposed changes

Ensure that floating labels work correctly on input elements without an explicit `type` attribute.

## Screenshots (if appropriate) or codepen:
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
