### PR TITLE
feat: add input function by typing to timepicker

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -116,14 +116,16 @@
       this._handleClockClickStartBound = this._handleClockClickStart.bind(this);
       this._handleDocumentClickMoveBound = this._handleDocumentClickMove.bind(this);
       this._handleDocumentClickEndBound = this._handleDocumentClickEnd.bind(this);
+      this._inputFromTextFieldBound = this._handleTimeInputEnterKey.bind(this);
 
       this.el.addEventListener('click', this._handleInputClickBound);
       this.el.addEventListener('keydown', this._handleInputKeydownBound);
       this.plate.addEventListener('mousedown', this._handleClockClickStartBound);
       this.plate.addEventListener('touchstart', this._handleClockClickStartBound);
+      this.digitalClock.addEventListener('keyup', this._inputFromTextFieldBound);
 
-      $(this.spanHours).on('click', this.showView.bind(this, 'hours'));
-      $(this.spanMinutes).on('click', this.showView.bind(this, 'minutes'));
+      $(this.inputHours).on('click', this.showView.bind(this, 'hours'));
+      $(this.inputMinutes).on('click', this.showView.bind(this, 'minutes'));
     }
 
     _removeEventHandlers() {
@@ -139,6 +141,13 @@
       if (e.which === M.keys.ENTER) {
         e.preventDefault();
         this.open();
+      }
+    }
+
+    _handleTimeInputEnterKey(e) {
+      if (e.which === M.keys.ENTER) {
+        e.preventDefault();
+        this._inputFromTextField();
       }
     }
 
@@ -211,7 +220,7 @@
 
       // Append popover to input by default
       const optEl = this.options.container;
-      let containerEl = (optEl instanceof HTMLElement?optEl:document.querySelector(optEl));
+      let containerEl = optEl instanceof HTMLElement ? optEl : document.querySelector(optEl);
       if (this.options.container && !!containerEl) {
         this.$modalEl.appendTo(containerEl);
       } else {
@@ -238,16 +247,17 @@
       this.vibrate = navigator.vibrate
         ? 'vibrate'
         : navigator.webkitVibrate
-          ? 'webkitVibrate'
-          : null;
+        ? 'webkitVibrate'
+        : null;
 
       this._canvas = this.modalEl.querySelector('.timepicker-canvas');
       this.plate = this.modalEl.querySelector('.timepicker-plate');
+      this.digitalClock = this.modalEl.querySelector('.timepicker-display-column');
 
       this.hoursView = this.modalEl.querySelector('.timepicker-hours');
       this.minutesView = this.modalEl.querySelector('.timepicker-minutes');
-      this.spanHours = this.modalEl.querySelector('.timepicker-span-hours');
-      this.spanMinutes = this.modalEl.querySelector('.timepicker-span-minutes');
+      this.inputHours = this.modalEl.querySelector('.timepicker-input-hours');
+      this.inputMinutes = this.modalEl.querySelector('.timepicker-input-minutes');
       this.spanAmPm = this.modalEl.querySelector('.timepicker-span-am-pm');
       this.footer = this.modalEl.querySelector('.timepicker-footer');
       this.amOrPm = 'PM';
@@ -341,7 +351,7 @@
       if (this.options.twelveHour) {
         for (let i = 1; i < 13; i += 1) {
           let tick = $tick.clone();
-          let radian = i / 6 * Math.PI;
+          let radian = (i / 6) * Math.PI;
           let radius = this.options.outerRadius;
           tick.css({
             left:
@@ -356,7 +366,7 @@
       } else {
         for (let i = 0; i < 24; i += 1) {
           let tick = $tick.clone();
-          let radian = i / 6 * Math.PI;
+          let radian = (i / 6) * Math.PI;
           let inner = i > 0 && i < 13;
           let radius = inner ? this.options.innerRadius : this.options.outerRadius;
           tick.css({
@@ -377,7 +387,7 @@
       // Minutes view
       for (let i = 0; i < 60; i += 5) {
         let tick = $tick.clone();
-        let radian = i / 30 * Math.PI;
+        let radian = (i / 30) * Math.PI;
         tick.css({
           left:
             this.options.dialRadius +
@@ -428,8 +438,8 @@
       }
       this.hours = +value[0] || 0;
       this.minutes = +value[1] || 0;
-      this.spanHours.innerHTML = this.hours;
-      this.spanMinutes.innerHTML = Timepicker._addLeadingZero(this.minutes);
+      this.inputHours.value = this.hours;
+      this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes);
 
       this._updateAmPmView();
     }
@@ -443,8 +453,8 @@
         hideView = isHours ? this.minutesView : this.hoursView;
       this.currentView = view;
 
-      $(this.spanHours).toggleClass('text-primary', isHours);
-      $(this.spanMinutes).toggleClass('text-primary', !isHours);
+      $(this.inputHours).toggleClass('text-primary', isHours);
+      $(this.inputMinutes).toggleClass('text-primary', !isHours);
 
       // Transition view
       hideView.classList.add('timepicker-dial-out');
@@ -483,6 +493,60 @@
       } else {
         this.setHand(x, y);
       }
+    }
+
+    _inputFromTextField() {
+      const isHours = this.currentView === 'hours';
+
+      if (isHours) {
+        const value = this['inputHours'].value;
+
+        if (value > 0 && value < 13) {
+          this.drawClockFromTimeInput(value, isHours);
+
+          this.showView('minutes', this.options.duration / 2);
+
+          this.hours = value;
+          this.inputMinutes.focus();
+        } else {
+          const hour = new Date().getHours();
+          this['inputHours'].value = hour % 12;
+        }
+      } else {
+        const value = this['inputMinutes'].value;
+
+        if (value >= 0 && value < 60) {
+          this['inputMinutes'].value = Timepicker._addLeadingZero(value);
+
+          this.drawClockFromTimeInput(value, isHours);
+
+          this.minutes = value;
+          this.modalEl.querySelector('.confirmation-btns :nth-child(2)').focus();
+        } else {
+          const minutes = new Date().getMinutes();
+          this['inputMinutes'].value = Timepicker._addLeadingZero(minutes);
+        }
+      }
+    }
+
+    drawClockFromTimeInput(value, isHours) {
+      const unit = Math.PI / (isHours ? 6 : 30);
+      const radian = value * unit;
+      let radius;
+
+      if (this.options.twelveHour) {
+        radius = this.options.outerRadius;
+      }
+
+      let cx1 = Math.sin(radian) * (radius - this.options.tickRadius),
+        cy1 = -Math.cos(radian) * (radius - this.options.tickRadius),
+        cx2 = Math.sin(radian) * radius,
+        cy2 = -Math.cos(radian) * radius;
+
+      this.hand.setAttribute('x2', cx1);
+      this.hand.setAttribute('y2', cy1);
+      this.bg.setAttribute('cx', cx2);
+      this.bg.setAttribute('cy', cy2);
     }
 
     setHand(x, y, roundBy5) {
@@ -547,9 +611,9 @@
 
       this[this.currentView] = value;
       if (isHours) {
-        this['spanHours'].innerHTML = value;
+        this['inputHours'].value = value;
       } else {
-        this['spanMinutes'].innerHTML = Timepicker._addLeadingZero(value);
+        this['inputMinutes'].value = Timepicker._addLeadingZero(value);
       }
 
       // Set clock hand and others' position
@@ -619,9 +683,9 @@
     '<div class="timepicker-digital-display">',
     '<div class="timepicker-text-container">',
     '<div class="timepicker-display-column">',
-    '<span class="timepicker-span-hours text-primary"></span>',
+    '<input type="text" maxlength="2" autofocus class="timepicker-input-hours text-primary" />',
     ':',
-    '<span class="timepicker-span-minutes"></span>',
+    '<input type="text" maxlength="2" class="timepicker-input-minutes" />',
     '</div>',
     '<div class="timepicker-display-column timepicker-display-am-pm">',
     '<div class="timepicker-span-am-pm"></div>',

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -11,12 +11,13 @@
 }
 
 .text-primary {
-	color: rgba(255, 255, 255, 1);
+  color: rgba(255, 255, 255, 1);
 }
 
 
 /* Clock Digital Display */
 .timepicker-digital-display {
+  width: 200px;
   flex: 1 auto;
   background-color: $secondary-color;
   padding: 10px;
@@ -24,27 +25,42 @@
 }
 
 .timepicker-text-container {
-	font-size: 4rem;
-	font-weight: bold;
-	text-align: center;
-	color: rgba(255, 255, 255, 0.6);
+  font-size: 4rem;
+  font-weight: bold;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
   font-weight: 400;
-	position: relative;
+  position: relative;
   user-select: none;
+
+  input[type=text]{
+    height: 4rem;
+    color: rgba(255, 255, 255, 0.6);
+    border-bottom: 0px;
+    font-size: 4rem;
+    direction: ltr;
+  }
 }
 
-.timepicker-span-hours,
-.timepicker-span-minutes,
+.timepicker-input-hours,
+.timepicker-input-minutes,
 .timepicker-span-am-pm div {
-	cursor: pointer;
+  cursor: pointer;
 }
 
-.timepicker-span-hours {
+input[type=text].timepicker-input-hours {
+  text-align: right;
+  width: 28%;
   margin-right: 3px;
 }
 
-.timepicker-span-minutes {
+input[type=text].timepicker-input-minutes {
+  width: 33%;
   margin-left: 3px;
+}
+
+input[type=text].text-primary {
+  color: rgba(255, 255, 255, 1);
 }
 
 .timepicker-display-am-pm {


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Following up [issue-118 Time Picker allow for typing input](https://github.com/materializecss/materialize/issues/118), I have added time input by typing functionality. The user can edit the time and minute on the digital clock directly while original functionality remains same. I have updated `/js/timepicker.js`. But I tested with `docs/js/materialize`. Please let me know if I picked up the wrong file. Once my direction is accepted, I will also add tests and update the documentation as well. And I would appreciate any feedback or other direction. I will quickly follow up. 

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->
![Screen Shot 2022-10-09 at 7 47 36 PM](https://user-images.githubusercontent.com/59734889/194785010-c28dc8cc-5a3f-48f7-8cc0-4b5878b4eb22.png)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
