### PR TITLE
fix(placeholder images): replace placehold.it with placeholder.com

### DIFF
--- a/docs/js/init.js
+++ b/docs/js/init.js
@@ -178,7 +178,7 @@
     $('.sidenav').sidenav();
     $('.tap-target').tapTarget();
     $('input.autocomplete').autocomplete({
-      data: { Apple: null, Microsoft: null, Google: 'http://placehold.it/250x250' }
+      data: { Apple: null, Microsoft: null, Google: 'https://via.placeholder.com/250x250' }
     });
     $('input[data-length], textarea[data-length]').characterCounter();
 

--- a/test/html/cards.html
+++ b/test/html/cards.html
@@ -153,7 +153,7 @@
       <div class="col s12 m6">
         <div class="card horizontal">
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
           <div class="card-stacked">
             <div class="card-content">
@@ -183,7 +183,7 @@
             </div>
           </div>
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
         </div>
       </div>
@@ -191,7 +191,7 @@
       <div class="col s12 m6">
         <div class="card horizontal">
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
           <div class="card-stacked">
             <div class="card-content">
@@ -213,7 +213,7 @@
             </div>
           </div>
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
         </div>
       </div>
@@ -221,7 +221,7 @@
       <div class="col s12 m6">
         <div class="card medium horizontal">
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
           <div class="card-stacked">
             <div class="card-content">
@@ -251,7 +251,7 @@
             </div>
           </div>
           <div class="card-image">
-            <img src="http://placehold.it/150x200/00ff00">
+            <img src="https://via.placeholder.com/150x200/00ff00">
           </div>
         </div>
       </div>

--- a/test/html/forms.html
+++ b/test/html/forms.html
@@ -320,8 +320,8 @@
     <h2>Select Icons</h2>
     <div class="input-field col s12">
       <select multiple>
-        <option value="1" data-icon="http://placehold.it/50x50" class="circle">Option 1</option>
-        <option value="2" data-icon="http://placehold.it/50x50" class="circle right">Option 2</option>
+        <option value="1" data-icon="https://via.placeholder.com/50x50" class="circle">Option 1</option>
+        <option value="2" data-icon="https://via.placeholder.com/50x50" class="circle right">Option 2</option>
         <option value="3">Option 3</option>
       </select>
       <label>Materialize Select Multiple</label>
@@ -330,11 +330,11 @@
     <div class="input-field col s12">
       <select>
         <optgroup label="team 1">
-          <option value="1" data-icon="http://placehold.it/50x50" class="circle">Option 1</option>
+          <option value="1" data-icon="https://via.placeholder.com/50x50" class="circle">Option 1</option>
           <option value="2">Option 2</option>
         </optgroup>
         <optgroup label="team 2">
-          <option value="3" data-icon="http://placehold.it/50x50" class="circle right">Option 3</option>
+          <option value="3" data-icon="https://via.placeholder.com/50x50" class="circle right">Option 3</option>
           <option value="4" selected>Option 4</option>
         </optgroup>
         <optgroup label="team 3">

--- a/tests/spec/autocomplete/autocompleteSpec.js
+++ b/tests/spec/autocomplete/autocompleteSpec.js
@@ -8,7 +8,7 @@ describe("Autocomplete Plugin", function () {
         data: {
           "Apple": null,
           "Microsoft": null,
-          "Google": 'http://placehold.it/250x250'
+          "Google": 'https://via.placeholder.com/250x250'
         }
       });
       done();
@@ -35,7 +35,7 @@ describe("Autocomplete Plugin", function () {
           data: {
             "Apple": null,
             "Microsoft": null,
-            "Google": 'http://placehold.it/250x250'
+            "Google": 'https://via.placeholder.com/250x250'
           }
         });
 

--- a/tests/spec/carousel/carouselFixture.html
+++ b/tests/spec/carousel/carouselFixture.html
@@ -1,14 +1,14 @@
 <div class="carousel carousel-slider" id="slider-no-wrap">
   <div class="carousel-item">
-    <img src="http://placehold.it/800x200">
+    <img src="https://via.placeholder.com/800x200">
   </div>
   <div class="carousel-item">
-    <img src="http://placehold.it/800x200">
+    <img src="https://via.placeholder.com/800x200">
   </div>
   <div class="carousel-item">
-    <img src="http://placehold.it/800x200">
+    <img src="https://via.placeholder.com/800x200">
   </div>
   <div class="carousel-item">
-    <img src="http://placehold.it/800x200">
+    <img src="https://via.placeholder.com/800x200">
   </div>
 </div>


### PR DESCRIPTION
fix #251

## Proposed changes
It seems that placehold.it has been cancelled. To get rid of the errors, I changed all to the matching API of placeholder.com

## Screenshots (if appropriate) or codepen:
![2022-10-10 13_43_54-NVIDIA GeForce Overlay DT](https://user-images.githubusercontent.com/6061136/194860328-0913eb18-ab43-48a7-9903-2eab273d81c9.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
