### PR TITLE
Select accessibility

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -145,7 +145,7 @@
             const selectOptions = $(realOption).children('option');
             let lId = "opt-group-" + M.guid();
             let groupParent = $(
-              `<li class="optgroup" role="group" aria-labelledby="${lId}"><span id="${lId}" role="presentation">${realOption.getAttribute('label')}</span></li>`
+              `<li class="optgroup" role="group" aria-labelledby="${lId}" tabindex="-1"><span id="${lId}" role="presentation">${realOption.getAttribute('label')}</span></li>`
             )[0];
             let groupChildren = [];
             $(this.dropdownOptions).append(groupParent);

--- a/js/select.js
+++ b/js/select.js
@@ -127,7 +127,7 @@
         'dropdown-content select-dropdown ' + (this.isMultiple ? 'multiple-select-dropdown' : '')
       );
       this.dropdownOptions.setAttribute("role", "listbox");
-      this.dropdownOptions.setAttribute("aria-required", this.$el.hasAttribute("required"));
+      this.dropdownOptions.setAttribute("aria-required", this.el.hasAttribute("required"));
       this.dropdownOptions.setAttribute("aria-multiselectable", this.isMultiple);
 
       // Create dropdown structure

--- a/js/select.js
+++ b/js/select.js
@@ -15,6 +15,8 @@
       this.isMultiple = this.$el.prop('multiple');
       this.el.tabIndex = -1;
       this._values = [];
+      this.labelEl = null;
+      this._labelFor = false;
       this._setupDropdown();
       this._setupEventHandlers();
     }
@@ -29,6 +31,8 @@
       return domElem.M_FormSelect;
     }
     destroy() {
+      // Returns label to its original owner
+      if (this._labelFor) this.labelEl.setAttribute("for", this.el.id);
       this._removeEventHandlers();
       this._removeDropdown();
       this.el.M_FormSelect = undefined;
@@ -41,6 +45,9 @@
         .find('li:not(.optgroup)')
         .each((el) => {
           el.addEventListener('click', this._handleOptionClickBound);
+          el.addEventListener('keydown', (e) => {
+            if (e.key === " " || e.key === "Enter") this._handleOptionClickBound(e);
+          });
         });
       this.el.addEventListener('change', this._handleSelectChangeBound);
       this.input.addEventListener('click', this._handleInputClickBound);
@@ -95,7 +102,7 @@
       if (!this.isMultiple) this.dropdown.close();
     }
     _handleInputClick() {
-      if (this.dropdown && this.dropdown.isOpen) {
+      if (this.dropdown && this.dropdown.isOpen) {  
         this._setValueToInput();
         this._setSelectedStates();
       }
@@ -119,6 +126,9 @@
       $(this.dropdownOptions).addClass(
         'dropdown-content select-dropdown ' + (this.isMultiple ? 'multiple-select-dropdown' : '')
       );
+      this.dropdownOptions.setAttribute("role", "listbox");
+      this.dropdownOptions.setAttribute("aria-required", this.$el.hasAttribute("required"));
+      this.dropdownOptions.setAttribute("aria-multiselectable", this.isMultiple);
 
       // Create dropdown structure
       if (this.$selectOptions.length) {
@@ -133,18 +143,23 @@
           } else if ($(realOption).is('optgroup')) {
             // Optgroup
             const selectOptions = $(realOption).children('option');
-            $(this.dropdownOptions).append(
-              $(
-                '<li class="optgroup"><span>' + realOption.getAttribute('label') + '</span></li>'
-              )[0]
-            );
+            let lId = "opt-group-" + M.guid();
+            let groupParent = $(
+              `<li class="optgroup" role="group" aria-labelledby="${lId}"><span id="${lId}" role="presentation">${realOption.getAttribute('label')}</span></li>`
+            )[0];
+            let groupChildren = [];
+            $(this.dropdownOptions).append(groupParent);
             selectOptions.each((realOption) => {
               const virtualOption = this._createAndAppendOptionWithIcon(
                 realOption,
                 'optgroup-option'
               );
+              let cId = "opt-child-" + M.guid();
+              virtualOption.id = cId;
+              groupChildren.push(cId);
               this._addOptionToValues(realOption, virtualOption);
             });
+            groupParent.setAttribute("aria-owns", groupChildren.join(" "));
           }
         });
       }
@@ -152,18 +167,62 @@
 
       // Add input dropdown
       this.input = document.createElement('input');
+      this.input.id = "m_select-input-" + M.guid();
       $(this.input).addClass('select-dropdown dropdown-trigger');
       this.input.setAttribute('type', 'text');
       this.input.setAttribute('readonly', 'true');
       this.input.setAttribute('data-target', this.dropdownOptions.id);
+      this.input.setAttribute('aria-readonly', 'true');
       if (this.el.disabled) $(this.input).prop('disabled', 'true');
+
+      // Makes new element to assume HTML's select label and
+      //   aria-attributes, if exists
+      if (this.el.hasAttribute("aria-labelledby")){
+        this.labelEl = document.getElementById(this.el.getAttribute("aria-labelledby"));
+      }
+      else if (this.el.id != ""){
+        let lbl = $(`label[for='${this.el.id}']`);
+        if (lbl.length){
+          this.labelEl = lbl[0];
+          this.labelEl.removeAttribute("for");
+          this._labelFor = true;
+        }
+      }
+      // Tries to find a valid label in parent element
+      if (!this.labelEl){
+        let el = this.el.parentElement;
+        if (el) el = el.getElementsByTagName("label")[0];
+        if (el) this.labelEl = el;
+      }
+      if (this.labelEl && this.labelEl.id == ""){
+        this.labelEl.id = "m_select-label-" + M.guid();
+      }
+
+      if (this.labelEl){
+        this.labelEl.setAttribute("for", this.input.id);
+        this.dropdownOptions.setAttribute("aria-labelledby", this.labelEl.id);
+      }
+      else this.dropdownOptions.setAttribute("aria-label", "");
+
+      let attrs = this.el.attributes;
+      for (let i = 0; i < attrs.length; ++i){
+        const attr = attrs[i];
+        if (attr.name.startsWith("aria-"))
+          this.input.setAttribute(attr.name, attr.value);
+      }
+
+      // Adds aria-attributes to input element
+      this.input.setAttribute("role", "combobox");
+      this.input.setAttribute("aria-owns", this.dropdownOptions.id);
+      this.input.setAttribute("aria-controls", this.dropdownOptions.id);
+      this.input.setAttribute("aria-expanded", false);
 
       $(this.wrapper).prepend(this.input);
       this._setValueToInput();
 
       // Add caret
       let dropdownIcon = $(
-        '<svg class="caret" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
+        '<svg class="caret" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>'
       );
       $(this.wrapper).prepend(dropdownIcon[0]);
       // Initialize dropdown
@@ -171,6 +230,7 @@
         let dropdownOptions = $.extend({}, this.options.dropdownOptions);
         dropdownOptions.coverTrigger = false;
         let userOnOpenEnd = dropdownOptions.onOpenEnd;
+        let userOnCloseEnd = dropdownOptions.onCloseEnd;
         // Add callback for centering selected option when dropdown content is scrollable
         dropdownOptions.onOpenEnd = (el) => {
           let selectedOption = $(this.dropdownOptions)
@@ -191,9 +251,19 @@
               this.dropdownOptions.scrollTop = scrollOffset;
             }
           }
+          // Sets "aria-expanded" to "true"
+          this.input.setAttribute("aria-expanded", true);
           // Handle user declared onOpenEnd if needed
           if (userOnOpenEnd && typeof userOnOpenEnd === 'function')
             userOnOpenEnd.call(this.dropdown, this.el);
+        };
+        // Add callback for reseting "expanded" state
+        dropdownOptions.onCloseEnd = (el) => {
+          // Sets "aria-expanded" to "false"
+          this.input.setAttribute("aria-expanded", false);
+          // Handle user declared onOpenEnd if needed
+          if (userOnCloseEnd && typeof userOnCloseEnd === 'function')
+            userOnCloseEnd.call(this.dropdown, this.el);
         };
         // Prevent dropdown from closing too early
         dropdownOptions.closeOnClick = false;
@@ -216,7 +286,11 @@
     }
     _createAndAppendOptionWithIcon(realOption, type) {
       const li = document.createElement('li');
-      if (realOption.disabled) li.classList.add('disabled');
+      li.setAttribute("role", "option");
+      if (realOption.disabled){
+        li.classList.add('disabled');
+        li.setAttribute("aria-disabled", true);
+      }
       if (type === 'optgroup-option') li.classList.add(type);
       // Text / Checkbox
       const span = document.createElement('span');
@@ -231,6 +305,7 @@
       const classes = realOption.getAttribute('class');
       if (iconUrl) {
         const img = $(`<img alt="" class="${classes}" src="${iconUrl}">`);
+        img[0].setAttribute("aria-hidden", true);
         li.prepend(img[0]);
       }
       // Check for multiple type
@@ -241,12 +316,14 @@
     _selectValue(value) {
       value.el.selected = true;
       value.optionEl.classList.add('selected');
+      value.optionEl.setAttribute("aria-selected", true);
       const checkbox = value.optionEl.querySelector('input[type="checkbox"]');
       if (checkbox) checkbox.checked = true;
     }
     _deselectValue(value) {
       value.el.selected = false;
       value.optionEl.classList.remove('selected');
+      value.optionEl.setAttribute("aria-selected", false);
       const checkbox = value.optionEl.querySelector('input[type="checkbox"]');
       if (checkbox) checkbox.checked = false;
     }
@@ -290,13 +367,17 @@
           .prop('checked', optionIsSelected);
         if (optionIsSelected) {
           this._activateOption($(this.dropdownOptions), $(value.optionEl));
-        } else $(value.optionEl).removeClass('selected');
+        } else {
+          $(value.optionEl).removeClass('selected');
+          $(value.optionEl).attr("aria-selected", false);
+        }
       });
     }
     _activateOption(ul, li) {
       if (!li) return;
       if (!this.isMultiple) ul.find('li.selected').removeClass('selected');
       $(li).addClass('selected');
+      $(li).attr("aria-selected", true);
     }
 
     getSelectedValues() {

--- a/pug/page-contents/select_content.html
+++ b/pug/page-contents/select_content.html
@@ -11,13 +11,13 @@
           <form class="col s12">
             <div class="row">
               <div class="input-field col s12 m6">
-                <select>
+                <select id="select-example-1">
                   <option value="" disabled selected>Choose your option</option>
                   <option value="1">Option 1</option>
                   <option value="2">Option 2</option>
                   <option value="3">Option 3</option>
                 </select>
-                <label>Materialize Select</label>
+                <label for="select-example-1">Materialize Select</label>
               </div>
               <div class="col s12">
                 <br>
@@ -25,20 +25,20 @@
                   <code class="language-markup">multiple</code> to get the multiple select and select several options.</p>
               </div>
               <div class="input-field col s12 m6">
-                <select multiple>
+                <select id="select-example-2" multiple>
                   <option value="" disabled selected>Choose your option</option>
                   <option value="1">Option 1</option>
                   <option value="2">Option 2</option>
                   <option value="3">Option 3</option>
                 </select>
-                <label>Materialize Multiple Select</label>
+                <label for="select-example-2">Materialize Multiple Select</label>
               </div>
               <div class="col s12">
                 <br>
                 <p>We also support optgroups in our selects.</p>
               </div>
               <div class="input-field col s12 m6">
-                <select>
+                <select id="select-example-3">
                   <optgroup label="team 1">
                     <option value="1">Option 1</option>
                     <option value="2">Option 2</option>
@@ -48,7 +48,7 @@
                     <option value="4">Option 4</option>
                   </optgroup>
                 </select>
-                <label>Optgroups</label>
+                <label for="select-example-3">Optgroups</label>
               </div>
               <div class="col s12">
                 <br>
@@ -56,22 +56,22 @@
                   <code class="language-markup">data-icon</code> attribute.</p>
               </div>
               <div class="input-field col s12 m6">
-                <select class="icons">
+                <select id="select-example-4" class="icons">
                   <option value="" disabled selected>Choose your option</option>
                   <option value="" data-icon="images/sample-1.jpg">example 1</option>
                   <option value="" data-icon="images/office.jpg">example 2</option>
                   <option value="" data-icon="images/yuna.jpg">example 3</option>
                 </select>
-                <label>Images in select</label>
+                <label for="select-example-4">Images in select</label>
               </div>
               <div class="input-field col s12 m6">
-                <select class="icons">
+                <select id="select-example-5" class="icons">
                   <option value="" disabled selected>Choose your option</option>
                   <option value="" data-icon="images/sample-1.jpg" class="left">example 1</option>
                   <option value="" data-icon="images/office.jpg" class="left">example 2</option>
                   <option value="" data-icon="images/yuna.jpg" class="left">example 3</option>
                 </select>
-                <label>Images in select</label>
+                <label for="select-example-5">Images in select</label>
               </div>
               <div class="col s12">
                 <br>
@@ -79,8 +79,8 @@
                   <code class="language-markup">browser-default</code> to get the browser default.</p>
               </div>
               <div class="col s12 m6">
-                <label>Browser Select</label>
-                <select class="browser-default">
+                <label for="select-example-6">Browser Select</label>
+                <select id="select-example-6" class="browser-default">
                   <option value="" disabled selected>Choose your option</option>
                   <option value="1">Option 1</option>
                   <option value="2">Option 2</option>
@@ -92,27 +92,27 @@
           <div class="col s12">
             <pre><code class="language-markup">
   &lt;div class="input-field col s12">
-    &lt;select>
+    &lt; id="form-select-1">
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="1">Option 1&lt;/option>
       &lt;option value="2">Option 2&lt;/option>
       &lt;option value="3">Option 3&lt;/option>
     &lt;/select>
-    &lt;label>Materialize Select&lt;/label>
+    &lt;label for="form-select-1">Materialize Select&lt;/label>
   &lt;/div>
 
   &lt;div class="input-field col s12">
-    &lt;select multiple>
+    &lt;select id="form-select-2" multiple>
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="1">Option 1&lt;/option>
       &lt;option value="2">Option 2&lt;/option>
       &lt;option value="3">Option 3&lt;/option>
     &lt;/select>
-    &lt;label>Materialize Multiple Select&lt;/label>
+    &lt;label for="form-select-2">Materialize Multiple Select&lt;/label>
   &lt;/div>
 
   &lt;div class="input-field col s12">
-    &lt;select>
+    &lt;select id="form-select-3">
       &lt;optgroup label="team 1">
         &lt;option value="1">Option 1&lt;/option>
         &lt;option value="2">Option 2&lt;/option>
@@ -122,30 +122,30 @@
         &lt;option value="4">Option 4&lt;/option>
       &lt;/optgroup>
     &lt;/select>
-    &lt;label>Optgroups&lt;/label>
+    &lt;label for="form-select-3">Optgroups&lt;/label>
   &lt;/div>
 
   &lt;div class="input-field col s12 m6">
-    &lt;select class="icons">
+    &lt;select id="form-select-4" class="icons">
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="" data-icon="images/sample-1.jpg">example 1&lt;/option>
       &lt;option value="" data-icon="images/office.jpg">example 2&lt;/option>
       &lt;option value="" data-icon="images/yuna.jpg">example 3&lt;/option>
     &lt;/select>
-    &lt;label>Images in select&lt;/label>
+    &lt;label for="form-select-4">Images in select&lt;/label>
   &lt;/div>
   &lt;div class="input-field col s12 m6">
-    &lt;select class="icons">
+    &lt;select id="form-select-5" class="icons">
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="" data-icon="images/sample-1.jpg" class="left">example 1&lt;/option>
       &lt;option value="" data-icon="images/office.jpg" class="left">example 2&lt;/option>
       &lt;option value="" data-icon="images/yuna.jpg" class="left">example 3&lt;/option>
     &lt;/select>
-    &lt;label>Images in select&lt;/label>
+    &lt;label for="form-select-5">Images in select&lt;/label>
   &lt;/div>
 
-  &lt;label>Browser Select&lt;/label>
-  &lt;select class="browser-default">
+  &lt;label for="form-select-6">Browser Select&lt;/label>
+  &lt;select id="form-select-6" class="browser-default">
     &lt;option value="" disabled selected>Choose your option&lt;/option>
     &lt;option value="1">Option 1&lt;/option>
     &lt;option value="2">Option 2&lt;/option>
@@ -286,6 +286,11 @@ instance.destroy();
               <td>Dropdown UL element.</td>
             </tr>
             <tr>
+              <td>labelEl</td>
+              <td>Element</td>
+              <td>Label associated with the current select element. Is "null", if not detected.</td>
+            </tr>
+            <tr>
               <td>input</td>
               <td>Element</td>
               <td>Text input that shows current selected option.</td>
@@ -312,19 +317,19 @@ instance.destroy();
           <form class="col s12 m6">
             <div class="row">
               <div class="col s12 input-field">
-                <select disabled>
+                <select id="select-example-7" disabled>
                   <option value="" disabled selected>Choose your option</option>
                   <option value="1">Option 1</option>
                   <option value="2">Option 2</option>
                   <option value="3">Option 3</option>
                 </select>
-                <label>Materialize Disabled</label>
+                <label for="select-example-7">Materialize Disabled</label>
               </div>
             </div>
             <div class="row">
               <div class="col s12">
-                <label>Browser Disabled</label>
-                <select class="browser-default" disabled>
+                <label for="select-example-8">Browser Disabled</label>
+                <select id="select-example-8" class="browser-default" disabled>
                   <option value="" disabled selected>Choose your option</option>
                   <option value="1">Option 1</option>
                   <option value="2">Option 2</option>
@@ -336,17 +341,17 @@ instance.destroy();
           <div class="col s12">
             <pre><code class="language-markup">
   &lt;div class="input-field">
-    &lt;select disabled>
+    &lt;select id="form-select-7" disabled>
       &lt;option value="" disabled selected>Choose your option&lt;/option>
       &lt;option value="1">Option 1&lt;/option>
       &lt;option value="2">Option 2&lt;/option>
       &lt;option value="3">Option 3&lt;/option>
     &lt;/select>
-    &lt;label>Materialize Disabled&lt;/label>
+    &lt;label for="form-select-7">Materialize Disabled&lt;/label>
   &lt;/div>
 
-  &lt;label>Browser Disabled&lt;/label>
-  &lt;select class="browser-default" disabled>
+  &lt;label for="form-select-8">Browser Disabled&lt;/label>
+  &lt;select id="form-select-8" class="browser-default" disabled>
     &lt;option value="" disabled selected>Choose your option&lt;/option>
     &lt;option value="1">Option 1&lt;/option>
     &lt;option value="2">Option 2&lt;/option>

--- a/test/html/select.html
+++ b/test/html/select.html
@@ -30,25 +30,25 @@
 
     <div class="row">
       <div class="input-field col s12 m6">
-        <select>
+        <select id="select-test-1">
           <option value="" disabled selected>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
         </select>
-        <label>Single-Select</label>
+        <label for="select-test-1">Single-Select</label>
         <div>
           <button class="btn1">Get Single-Select Values</button>
         </div>
       </div>
       <div class="input-field col s12 m6">
-        <select multiple>
+        <select id="select-test-2" multiple>
           <option value="" disabled>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
           <option value="3">Option 3</option>
         </select>
-        <label>Multi-Select</label>
+        <label for="select-test-2">Multi-Select</label>
         <div>
           <button class="btn2">Get Multi-Select Values</button>
         </div>
@@ -56,7 +56,7 @@
     </div>
 
     <div class="input-field col s12">
-      <select>
+      <select id="select-test-3">
         <optgroup label="team 1">
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
@@ -66,44 +66,44 @@
           <option value="4">Option 4</option>
         </optgroup>
       </select>
-      <label>Single-Select with Optgroups</label>
+      <label for="select-test-3">Single-Select with Optgroups</label>
     </div>
 
     <div class="row">
       <h5>Selects with Images</h5>
       <div class="input-field col s12 m6">
-        <select class="icons">
+        <select id="select-test-4" class="icons">
           <option value="" disabled selected>Choose your option</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_c.png">example 3</option>
         </select>
-        <label>Single-Select with Images (right)</label>
+        <label for="select-test-4">Single-Select with Images (right)</label>
       </div>
       <div class="input-field col s12 m6">
-        <select class="icons">
+        <select id="select-test-5" class="icons">
           <option value="" disabled selected>Choose your option</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_a.png" class="left">example 1</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_b.png" class="left">example 2</option>
           <option value="" data-icon="../../docs/images/placeholder/250x250_c.png" class="left">example 3</option>
         </select>
-        <label>Single-Select with Images (left)</label>
+        <label for="select-test-5">Single-Select with Images (left)</label>
       </div>
     </div>
 
     <div class="row">
       <h5>Select with selected Options</h5>
       <div class="input-field col s12 m6">
-        <select>
+        <select id="select-test-6">
           <option value="" disabled>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2" selected>Option 2</option>
           <option value="3">Option 3</option>
         </select>
-        <label>Single-Select with Value set</label>
+        <label for="select-test-6">Single-Select with Value set</label>
       </div>
       <div class="input-field col s12 m6">
-        <select multiple class="icons">
+        <select id="select-test-7" multiple class="icons">
           <option value="" disabled selected>Choose your option</option>
           <option value="1" selected data-icon="../../docs/images/placeholder/250x250_a.png">example 1</option>
           <option value="2" selected data-icon="../../docs/images/placeholder/250x250_b.png">example 2</option>
@@ -112,26 +112,26 @@
           <option value="5" data-icon="../../docs/images/placeholder/250x250_e.png">example 4</option>
           <option value="6">example 5</option>
         </select>
-        <label>Multi-Select with Images (right) and Pre-Selections</label>
+        <label for="select-test-7">Multi-Select with Images (right) and Pre-Selections</label>
       </div>
     </div>
 
     <div class="row">
       <h5>Dynamically generated Select-Options <button class="btn3">Create + Init Select</button></h5>
       <div class="input-field col s12 m6">
-        <select class="dynamic-select-single"></select>
-        <label>Dynamic Single-Select</label>
+        <select id="select-test-8" class="dynamic-select-single"></select>
+        <label for="select-test-8">Dynamic Single-Select</label>
       </div>
       <div class="input-field col s12 m6">
-        <select class="dynamic-select-multi" multiple></select>
-        <label>Dynamic Multi-Select</label>
+        <select id="select-test-9" class="dynamic-select-multi" multiple></select>
+        <label for="select-test-9">Dynamic Multi-Select</label>
       </div>
     </div>
 
     <div class="row">
       <div class="col s12 m6">
-        <label>Browser Single-Select</label>
-        <select class="browser-default">
+        <label for="select-test-10">Browser Single-Select</label>
+        <select id="select-test-10" class="browser-default">
           <option value="" disabled selected>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>
@@ -139,8 +139,8 @@
         </select>
       </div>
       <div class="col s12 m6">
-        <label>Browser Multi-Select</label>
-        <select class="browser-default" multiple style="height:150px;">
+        <label for="select-test-11">Browser Multi-Select</label>
+        <select id="select-test-11" class="browser-default" multiple style="height:150px;">
           <option value="" disabled selected>Choose your option</option>
           <option value="1">Option 1</option>
           <option value="2">Option 2</option>

--- a/tests/spec/select/selectSpec.js
+++ b/tests/spec/select/selectSpec.js
@@ -37,6 +37,7 @@ describe("Select Plugin", function () {
         setTimeout(function() {
           expect(normalDropdown).toBeHidden('Should be hidden after choosing item.');
           expect(normalInput.value).toEqual(firstOption.innerText, 'Value should equal chosen option.');
+          expect(firstOption.getAttribute('aria-selected')).toBe('true', 'Item be selected to assistive technologies.');
           done();
         }, 400);
       }, 400);
@@ -48,6 +49,7 @@ describe("Select Plugin", function () {
 
       let firstOption = browserSelect.querySelector('option[selected]');
       expect(normalInput.value).toEqual(firstOption.innerText, 'Value should be equal to preselected option.');
+      expect(firstOption.getAttribute("aria-selected"), "First item should be selected to assistive technologies.")
     });
 
     it("should not initialize if browser default", function () {
@@ -85,6 +87,10 @@ describe("Select Plugin", function () {
       selectInstance = M.FormSelect.getInstance(browserSelect);
     });
 
+    it("Dropdown should allow multiple selections to assistive technologies", function(){
+      expect(selectInstance.dropdownOptions.getAttribute("aria-multiselectable")).toBe("true");
+    });
+
     it("should open dropdown and select multiple options", function(done) {
       multipleInput = selectInstance.wrapper.querySelector('input.select-dropdown');
       multipleDropdown = selectInstance.wrapper.querySelector('ul.select-dropdown');
@@ -106,12 +112,19 @@ describe("Select Plugin", function () {
           firstOption = multipleDropdown.querySelector('li:not(.disabled)');
           let secondOption = multipleDropdown.querySelectorAll('li:not(.disabled)')[1];
           let thirdOption = multipleDropdown.querySelectorAll('li:not(.disabled)')[2];
-          let selectedVals =
-            Array.prototype.slice.call(browserSelect.querySelectorAll('option:checked'), 0).map(function(v) { 
+          let selectedVals = Array.prototype.slice.call(browserSelect.querySelectorAll('option:checked'), 0).map(function(v) { 
             return v.value; 
+          });
+          let selectedAria = Array.prototype.slice.call(multipleDropdown.querySelectorAll('li.selected'), 0).map(function(v) { 
+            return v.getAttribute("aria-selected"); 
+          });
+          let unselectedAria = Array.prototype.slice.call(multipleDropdown.querySelectorAll('li:not(.selected)'), 0).map(function(v) { 
+            return v.getAttribute("aria-selected"); 
           });
           expect(multipleDropdown).toBeHidden('Should be hidden after choosing item.');
           expect(selectedVals).toEqual(['1', '2', '3'], 'Actual select should have correct selected values.');
+          expect(selectedAria).toEqual(['true', 'true', 'true'], 'Selected values should be checked to assistive technologies.');
+          expect(unselectedAria).toEqual(['false'], 'Unselected values should be checked to assistive technologies.');
           expect(multipleInput.value).toEqual(firstOption.innerText + ', ' + secondOption.innerText + ', ' + thirdOption.innerText, 'Value should equal chosen multiple options.');
           done();
         }, 400);
@@ -165,6 +178,22 @@ describe("Select Plugin", function () {
     beforeEach(function() {
       browserSelect = document.querySelector('select.optgroup');
       selectInstance = M.FormSelect.getInstance(browserSelect);
+    });
+
+    it("Option groups should behave as such for assistive technologies", function(){
+      optInput = selectInstance.wrapper.querySelector('input.select-dropdown');
+      optDropdown = selectInstance.wrapper.querySelector('ul.select-dropdown');
+
+      let optgroups = optDropdown.querySelectorAll('li.optgroup');
+      let browerSelectOptgroups = browserSelect.querySelectorAll('optgroup');
+
+      for (let i = 0; i < browerSelectOptgroups.length; i++) {
+        expect(optgroups[i].getAttribute("role")).toBe("group", "Should behave as group.");
+      }
+      for (let i = 0; i < browerSelectOptgroups.length; i++) {
+        expect(browerSelectOptgroups[i].children.length).toBe(optgroups[i].getAttribute("aria-owns").split(" ").length,
+          "Browser option groups and custom groups must have the same ammount of children for assistive technologies");
+      }
     });
 
     it("should open dropdown and select options", function(done) {


### PR DESCRIPTION
## Proposed changes

Resolved some semantic issues in select component so as to enhance performance of assistive technologies (e.g.: screen readers).

In spite of not affecting existing projects, this PR must improve the component's overall accessibility concerns, since it fixes some HTML semantic issues (for assistive technologies) and improves keyboard navigation, in addition to better semantics in code samples available in the docs.

**Summary**:

- Add missing "ARIA" attributes to custom input, dropdown and list items:
    - Fix HTML semantic roles by adding "combobox", "listbox" and "option" roles, respectively;
    - Custom input element is now "read-only" for screen readers as well;
    - Custom input element "controls" dropdown;
    - Improved element hierarchy to assistive technologies by adding references to equivalent child elements (through "aria-owns");
    - Improved listbox "expanded state" detection by assistive technologies;
    - Add "selected" and "enabled" state to option items.
- Enhance support to select with optgroups:
    - Group names are no longer focusable on keyboard navigation;
    - Group child items are hierarchically referenced (see screenshots).
- "Original" select's label is referenced by custom input while custom instance is active (the label should return to its original state as soon as the instance is destroyed);
- Item images should be ignored by assistive technologies, since their purpose is solely decorative and was lacking "alt" attribute;
- Improve docs so as to give accessible code samples😄.

**NB.:** Although this PR should solve semantic-wise issues with assistive technologies, select components are still affected by the lack of "focus style" as discribed in #81.

## Screenshots (if appropriate) or codepen:

Here are some screenshots of how the select component is detected by assistive technologies:

### Single select

![Firefox development tools displaying accessibility properties for single select component.](https://user-images.githubusercontent.com/7539096/202873607-70471cea-2e40-493b-8712-211ad595d6dd.png "Firefox dev tools screenshot")

### Multiple select

![Firefox development tools displaying accessibility properties for multiple select component](https://user-images.githubusercontent.com/7539096/202873965-23e95cd1-7d0c-487d-b2de-52c7027476ed.png "Firefox dev tools screenshot")

### Select with optgroup

![Firefox development tools displaying accessibility properties for single select component with option groups](https://user-images.githubusercontent.com/7539096/202874305-7455764c-a16f-4d76-95c7-a59699b71ad2.png "Firefox dev tools screenshot")


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
