### PR TITLE
fix: remove postinstall hook from packed package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@materializecss/materialize",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@materializecss/materialize",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
@@ -43,6 +43,7 @@
         "lint-staged": "^7.0.5",
         "node-archiver": "^0.3.0",
         "phantomjs-prebuilt": "^2.1.14",
+        "pinst": "^3.0.0",
         "prettier": "^1.12.1",
         "sass": "^1.35.2"
       }
@@ -10745,6 +10746,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinst": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-3.0.0.tgz",
+      "integrity": "sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "pinst": "bin.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -23184,6 +23198,12 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
+    },
+    "pinst": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-3.0.0.tgz",
+      "integrity": "sha512-cengSmBxtCyaJqtRSvJorIIZXMXg+lJ3sIljGmtBGUVonMnMsVJbnzl6jGN1HkOWwxNuJynCJ2hXxxqCQrFDdw==",
+      "dev": true
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "precommit": "lint-staged",
     "docs": "grunt docs",
     "commit": "npx cz",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "prepack": "pinst --disable",
+    "postpack": "pinst --enable"
   },
   "lint-staged": {
     "js/*.js": [
@@ -65,6 +67,7 @@
     "lint-staged": "^7.0.5",
     "node-archiver": "^0.3.0",
     "phantomjs-prebuilt": "^2.1.14",
+    "pinst": "^3.0.0",
     "prettier": "^1.12.1",
     "sass": "^1.35.2"
   },


### PR DESCRIPTION
## Proposed changes
Add pinst to disable postinstall hook while packaging to fix install errors... fixes #310 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [ ] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
