### PR TITLE
Update toast to improve unsafeHtml.

### DIFF
--- a/js/toasts.js
+++ b/js/toasts.js
@@ -218,7 +218,7 @@
         toast.appendChild(this.htmlMessage);
       } else if (!!this.htmlMessage.jquery) {
         // Check if it is jQuery object, append the node
-        $(toast).append(this.htmlMessage[0]);
+        $(toast).append(this.htmlMessage);
       } else {
         // Append as unsanitized html;
         $(toast).append(this.htmlMessage);


### PR DESCRIPTION
As today we are still using jQuery and recently switched from version 0.100 to 1.2.0 of Materialize.

In our migration I noticed that html in toast is no more working as expected with an array of jQuery elements.

You can easily try it by passing this snippet to the unsafeHtml property: `$('<p>Foo</p>').add($('<p>Bar</p>'))`

## Proposed changes
Removing the index of the array so that it works both with a single jQuery element and with an array of jQuery elements.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
