### PR TITLE
fix(select): misplaced aria-required attribute

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -127,7 +127,6 @@
         'dropdown-content select-dropdown ' + (this.isMultiple ? 'multiple-select-dropdown' : '')
       );
       this.dropdownOptions.setAttribute("role", "listbox");
-      this.dropdownOptions.setAttribute("aria-required", this.el.hasAttribute("required"));
       this.dropdownOptions.setAttribute("aria-multiselectable", this.isMultiple);
 
       // Create dropdown structure
@@ -173,6 +172,7 @@
       this.input.setAttribute('readonly', 'true');
       this.input.setAttribute('data-target', this.dropdownOptions.id);
       this.input.setAttribute('aria-readonly', 'true');
+      this.input.setAttribute("aria-required", this.el.hasAttribute("required"));
       if (this.el.disabled) $(this.input).prop('disabled', 'true');
 
       // Makes new element to assume HTML's select label and


### PR DESCRIPTION
Assign "aria-required" attribute to input element rather than options dropdown.

## Proposed changes

Select elements with "required" attribute are now correctly recognized by assistive technologies.

**NB:** No "visual" changes must take place and no additional "test cases" seems to be necessary.

## Screenshots (if appropriate) or codepen:

![Screenshot of a required "select" component test displaying acessibility attributes.](https://user-images.githubusercontent.com/7539096/206867002-46f252b4-4c00-4ad6-9355-8effdc5f651e.png "Screenshot of a required ''select'' component test displaying acessibility attributes.")

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
