### PR TITLE
Carousel accessibility

### DIFF
--- a/pug/page-contents/carousel_content.html
+++ b/pug/page-contents/carousel_content.html
@@ -11,33 +11,35 @@
 
         <div class="carousel">
           <a class="carousel-item" href="#one!">
-            <img src="images/placeholder/250x250_a.png">
+            <img src="images/placeholder/250x250_a.png" alt="Letter 'A' inside a red squared box.">
           </a>
           <a class="carousel-item" href="#two!">
-            <img src="images/placeholder/250x250_b.png">
+            <img src="images/placeholder/250x250_b.png" alt="Letter 'B' inside a blue squared box.">
           </a>
           <a class="carousel-item" href="#three!">
-            <img src="images/placeholder/250x250_c.png">
+            <img src="images/placeholder/250x250_c.png" alt="Letter 'C' inside a yellow squared box.">
           </a>
           <a class="carousel-item" href="#four!">
-            <img src="images/placeholder/250x250_d.png">
+            <img src="images/placeholder/250x250_d.png" alt="Letter 'D' inside a purple squared box.">
           </a>
           <a class="carousel-item" href="#five!">
-            <img src="images/placeholder/250x250_e.png">
+            <img src="images/placeholder/250x250_e.png" alt="Letter 'E' inside a green squared box.">
           </a>
         </div>
         <br>
 
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-markup copiedText">
   &lt;div class="carousel">
-    &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/250x250_a.png">&lt;/a>
-    &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/250x250_b.png">&lt;/a>
-    &lt;a class="carousel-item" href="#three!">&lt;img src="images/placeholder/250x250_c.png">&lt;/a>
-    &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/250x250_d.png">&lt;/a>
-    &lt;a class="carousel-item" href="#five!">&lt;img src="images/placeholder/250x250_e.png">&lt;/a>
+    &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/250x250_a.png" alt="Letter 'A' inside a red squared box.">&lt;/a>
+    &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/250x250_b.png" alt="Letter 'B' inside a blue squared box.">&lt;/a>
+    &lt;a class="carousel-item" href="#three!">&lt;img src="images/placeholder/250x250_c.png" alt="Letter 'C' inside a yellow squared box.">&lt;/a>
+    &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/250x250_d.png" alt="Letter 'D' inside a purple squared box.">&lt;/a>
+    &lt;a class="carousel-item" href="#five!">&lt;img src="images/placeholder/250x250_e.png" alt="Letter 'E' inside a green squared box.">&lt;/a>
   &lt;/div>
           </code>
         </pre>
@@ -48,7 +50,9 @@
         <h3 class="header">Initialization</h3>
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-javascript copiedText">
   document.addEventListener('DOMContentLoaded', function() {
     var elems = document.querySelectorAll('.carousel');
@@ -136,6 +140,22 @@
               <td>null</td>
               <td>Callback for when a new slide is cycled to.</td>
             </tr>
+            <tr>
+              <td>indicatorLabelFunc</td>
+              <td>Function</td>
+              <td>null</td>
+              <td>
+                <p>
+                  Function used to generate ARIA label to indicators (for accessibility purposes).
+                </p>
+                <p>
+                  It receives the current index, starting from "1", and a boolean indicating whether it is the current element or not. 
+                </p>
+                <p>
+                  If not specified, the generated label is going to be the current index.
+                </p>
+              </td>
+            </tr>
           </tbody>
         </table>
         <br>
@@ -148,7 +168,9 @@
             instance like this: </p>
             <pre style="padding-top: 0px;">
               <span class="copyMessage">Copied!</span>
-              <i class="material-icons copyButton">content_copy</i>
+              <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+                <i class="material-icons" aria-hidden="true">content_copy</i>
+              </span>
               <code class="language-javascript col s12 copiedText">
   var instance = M.Carousel.getInstance(elem);
 
@@ -261,36 +283,40 @@ instance.destroy();
 
         <div class="carousel carousel-slider">
           <a class="carousel-item" href="#one!">
-            <img src="images/placeholder/800x400_a.jpg">
+            <img src="images/placeholder/800x400_a.jpg" alt="Placeholder image for first carousel item.">
           </a>
           <a class="carousel-item" href="#two!">
-            <img src="images/placeholder/800x400_b.jpg">
+            <img src="images/placeholder/800x400_b.jpg" alt="Placeholder image for second carousel item.">
           </a>
           <a class="carousel-item" href="#three!">
-            <img src="images/placeholder/800x400_c.jpg">
+            <img src="images/placeholder/800x400_c.jpg" alt="Placeholder image for third carousel item.">
           </a>
           <a class="carousel-item" href="#four!">
-            <img src="images/placeholder/800x400_d.jpg">
+            <img src="images/placeholder/800x400_d.jpg" alt="Placeholder image for fourth carousel item.">
           </a>
         </div>
         <br>
 
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-markup copiedText">
   &lt;div class="carousel carousel-slider">
-    &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/800x400_a.jpg">&lt;/a>
-    &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/800x400_b.jpg">&lt;/a>
-    &lt;a class="carousel-item" href="#three!">&lt;img src="images/placeholder/800x400_c.jpg">&lt;/a>
-    &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/800x400_d.jpg">&lt;/a>
+    &lt;a class="carousel-item" href="#one!">&lt;img src="images/placeholder/800x400_a.jpg" alt="Placeholder image for first carousel item.">&lt;/a>
+    &lt;a class="carousel-item" href="#two!">&lt;img src="images/placeholder/800x400_b.jpg" alt="Placeholder image for second carousel item.">&lt;/a>
+    &lt;a class="carousel-item" href="#three!">&lt;img src="images/placeholder/800x400_c.jpg" alt="Placeholder image for third carousel item.">&lt;/a>
+    &lt;a class="carousel-item" href="#four!">&lt;img src="images/placeholder/800x400_d.jpg" alt="Placeholder image for fourth carousel item.">&lt;/a>
   &lt;/div>
           </code>
         </pre>
 
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-javascript copiedText">
   var instance = M.Carousel.init({
     fullWidth: true
@@ -316,7 +342,7 @@ instance.destroy();
 
         <div class="carousel carousel-slider center">
           <div class="carousel-fixed-item center">
-            <a class="btn waves-effect white grey-text darken-text-2">button</a>
+            <button type="button" class="btn waves-effect white grey-text darken-text-2">button</button>
           </div>
           <div class="carousel-item red white-text" href="#one!">
             <h2>First Panel</h2>
@@ -338,7 +364,9 @@ instance.destroy();
         <br>
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-markup copiedText">
   &lt;div class="carousel carousel-slider center">
     &lt;div class="carousel-fixed-item center">
@@ -365,18 +393,34 @@ instance.destroy();
         </pre>
         <pre style="padding-top: 0px;">
           <span class="copyMessage">Copied!</span>
-          <i class="material-icons copyButton">content_copy</i>
+          <span class="copyButton" role="button" aria-label="Copy code to clipboard" tabindex="0">
+            <i class="material-icons" aria-hidden="true">content_copy</i>
+          </span>
           <code class="language-javascript copiedText">
   var instance = M.Carousel.init({
     fullWidth: true,
-    indicators: true
+    indicators: true,
+    indicatorLabelFunc: (idx, curr) => {
+      let label = "Go to slide " + idx;
+      if (current){
+        label = label + " (Current)";
+      }
+      return label;
+    }
   });
 
   // Or with jQuery
 
   $('.carousel.carousel-slider').carousel({
     fullWidth: true,
-    indicators: true
+    indicators: true,
+    indicatorLabelFunc: (idx, curr) => {
+      let label = "Go to slide " + idx;
+      if (current){
+        label = label + " (Current)";
+      }
+      return label;
+    }
   });
           </code>
         </pre>

--- a/sass/components/_carousel.scss
+++ b/sass/components/_carousel.scss
@@ -65,20 +65,30 @@
     margin: 0;
 
     .indicator-item {
-      &.active {
-        background-color: #fff;
-      }
-
       display: inline-block;
       position: relative;
-      cursor: pointer;
       height: 8px;
       width: 8px;
       margin: 24px 4px;
+      
+    }
+
+    .indicator-item-btn {
+      &.active {
+        background-color: #fff;
+      }
+      position: absolute;
+      top: 0;
+      left: 0;
+      cursor: pointer;
       background-color: rgba(255,255,255,.5);
 
       transition: background-color .3s;
       border-radius: 50%;
+      border-width: 0;
+
+      width: 100%;
+      height: 100%;
     }
   }
 

--- a/sass/components/_carousel.scss
+++ b/sass/components/_carousel.scss
@@ -86,6 +86,7 @@
       transition: background-color .3s;
       border-radius: 50%;
       border-width: 0;
+      padding: 0;
 
       width: 100%;
       height: 100%;

--- a/test/html/carousel.html
+++ b/test/html/carousel.html
@@ -29,11 +29,11 @@
         <div class="collapsible-header"><i class="material-icons">place</i>Second</div>
         <div class="collapsible-body">
           <div class="carousel">
-            <a class="carousel-item" href="#one!"><img src="../../images/placeholder/250x250_a.png"></a>
-            <a class="carousel-item" href="#two!"><img src="../../images/placeholder/250x250_b.png"></a>
-            <a class="carousel-item" href="#three!"><img src="../../images/placeholder/250x250_c.png"></a>
-            <a class="carousel-item" href="#four!"><img src="../../images/placeholder/250x250_d.png"></a>
-            <a class="carousel-item" href="#five!"><img src="../../images/placeholder/250x250_e.png"></a>
+            <a class="carousel-item" href="#one!"><img src="../../docs/images/placeholder/250x250_a.png" alt="Letter A"></a>
+            <a class="carousel-item" href="#two!"><img src="../../docs/images/placeholder/250x250_b.png" alt="Letter B"></a>
+            <a class="carousel-item" href="#three!"><img src="../../docs/images/placeholder/250x250_c.png" alt="Letter C"></a>
+            <a class="carousel-item" href="#four!"><img src="../../docs/images/placeholder/250x250_d.png" alt="Letter D"></a>
+            <a class="carousel-item" href="#five!"><img src="../../docs/images/placeholder/250x250_e.png" alt="Letter E"></a>
           </div>
         </div>
       </li>
@@ -50,18 +50,18 @@
     </ul>
     <div id="test1" class="col s12">
       <div class="carousel carousel-slider">
-        <a class="carousel-item" href="#one!"><img src="../../images/placeholder/800x400_a.jpg"></a>
-        <a class="carousel-item" href="#two!"><img src="../../images/placeholder/800x400_b.jpg"></a>
-        <a class="carousel-item" href="#three!"><img src="../../images/placeholder/800x400_c.jpg"></a>
-        <a class="carousel-item" href="#four!"><img src="../../images/placeholder/800x400_d.jpg"></a>
+        <a class="carousel-item" href="#one!"><img src="../../docs/images/placeholder/800x400_a.jpg" alt="First image sample"></a>
+        <a class="carousel-item" href="#two!"><img src="../../docs/images/placeholder/800x400_b.jpg" alt="Second image sample"></a>
+        <a class="carousel-item" href="#three!"><img src="../../docs/images/placeholder/800x400_c.jpg" alt="Third image sample"></a>
+        <a class="carousel-item" href="#four!"><img src="../../docs/images/placeholder/800x400_d.jpg" alt="Fourth image sample"></a>
       </div>
     </div>
     <div id="test2" class="col s12">
       <div class="carousel carousel-slider">
-        <a class="carousel-item" href="#one!"><img src="../../images/placeholder/800x400_a.jpg"></a>
-        <a class="carousel-item" href="#two!"><img src="../../images/placeholder/800x400_b.jpg"></a>
-        <a class="carousel-item" href="#three!"><img src="../../images/placeholder/800x400_c.jpg"></a>
-        <a class="carousel-item" href="#four!"><img src="../../images/placeholder/800x400_d.jpg"></a>
+        <a class="carousel-item" href="#one!"><img src="../../docs/images/placeholder/800x400_a.jpg" alt="First image sample"></a>
+        <a class="carousel-item" href="#two!"><img src="../../docs/images/placeholder/800x400_b.jpg" alt="Second image sample"></a>
+        <a class="carousel-item" href="#three!"><img src="../../docs/images/placeholder/800x400_c.jpg" alt="Third image sample"></a>
+        <a class="carousel-item" href="#four!"><img src="../../docs/images/placeholder/800x400_d.jpg" alt="Fourth image sample"></a>
       </div>
     </div>
 
@@ -81,12 +81,20 @@
 
       $('ul.tabs').tabs({
         onShow: function(tab) {
-          $('.carousel.carousel-slider').carousel({fullWidth : true});
+          $('.carousel.carousel-slider').carousel({
+            fullWidth : true,
+            indicators: true,
+            indicatorLabelFunc: (i, current) => 'Go to Slide ' + i + (current ? ' (Current)' : '')
+          });
         }
       });
 
       $('.carousel').carousel();
-      $('.carousel.carousel-slider').carousel({fullWidth : true});
+      $('.carousel.carousel-slider').carousel({
+        fullWidth : true,
+        indicators: true,
+        indicatorLabelFunc: (i, current) => 'Go to Slide ' + i + (current ? ' (Current)' : '')
+      });
     });
     </script>
 

--- a/tests/spec/carousel/carouselFixture.html
+++ b/tests/spec/carousel/carouselFixture.html
@@ -1,14 +1,14 @@
 <div class="carousel carousel-slider" id="slider-no-wrap">
   <div class="carousel-item">
-    <img src="https://via.placeholder.com/800x200">
+    <img src="https://via.placeholder.com/800x200" alt="First slide placeholder image">
   </div>
   <div class="carousel-item">
-    <img src="https://via.placeholder.com/800x200">
+    <img src="https://via.placeholder.com/800x200" alt="Second slide placeholder image">
   </div>
   <div class="carousel-item">
-    <img src="https://via.placeholder.com/800x200">
+    <img src="https://via.placeholder.com/800x200" alt="Third slide placeholder image">
   </div>
   <div class="carousel-item">
-    <img src="https://via.placeholder.com/800x200">
+    <img src="https://via.placeholder.com/800x200" alt="Fourth slide placeholder image">
   </div>
 </div>

--- a/tests/spec/carousel/carouselSpec.js
+++ b/tests/spec/carousel/carouselSpec.js
@@ -1,34 +1,60 @@
-describe("Carousel", function () {
+describe("Carousel", () => {
 
-  beforeEach(async function() {
+  beforeEach(async () => {
     await XloadFixtures(['carousel/carouselFixture.html']);
   });
-  afterEach(function(){
+
+  afterEach(() => {
     XunloadFixtures();
   });
 
-  describe("carousel plugin", function () {
+  describe("carousel plugin", () => {
 
-    // beforeEach(function() {
-    // });
-
-    it("No wrap next and prev should not overflow", function (done) {
+    it("No wrap next and prev should not overflow", (done) => {
       let noWrap = M.Carousel.init(
-        document.querySelector('#slider-no-wrap'), { noWrap: true }
+        document.querySelector("#slider-no-wrap"), { noWrap: true }
       );
       noWrap.prev();
 
-      expect(noWrap.center).toEqual(0, 'Prev should do nothing');
+      expect(noWrap.center).toEqual(0, "Prev should do nothing");
 
       noWrap.set(3);
-      setTimeout(function() {
+      setTimeout(() => {
         noWrap.next();
 
-        setTimeout(function() {
-          expect(noWrap.center).toEqual(3, 'Next should do nothing');
+        setTimeout(() => {
+          expect(noWrap.center).toEqual(3, "Next should do nothing");
+          noWrap.destroy();
 
           done();
         }, 400);
+      }, 400);
+    });
+
+    it("Label of indicators must start with 'Slide '", () => {
+      let carousel = M.Carousel.init(
+        document.querySelector("#slider-no-wrap"), {
+          indicators: true,
+          indicatorLabelFunc: (idx) => "Slide " + idx
+        }
+      );
+
+      expect(Array.from(document.querySelectorAll("button")).map((btn) =>
+        btn.getAttribute("aria-label").startsWith("Slide ")
+      )).toEqual([true, true, true, true]);
+      carousel.destroy();
+    });
+
+    it("Non-current slides must be hidden (fullWidth)", (done) => {
+      let carousel = M.Carousel.init(document.querySelector("#slider-no-wrap"), { fullWidth: true });
+
+      setTimeout(() => {
+        expect(Array.from(document.querySelectorAll(".carousel-item")).map((item) => item.style.visibility))
+          .toEqual(["visible", "", "", ""]);
+        expect(Array.from(document.querySelectorAll(".carousel-item")).map((item) => item.getAttribute("aria-hidden")))
+          .toEqual(["false", "true", "true", "true"]);
+        carousel.destroy();
+        done();
       }, 400);
     });
 


### PR DESCRIPTION
## Proposed changes

Enhanced accessibility performance of Materialize's Carousel component by adding proper ARIA attributes and better support to keyboard navigation.

Following [W3C's accessible carousel example](https://www.w3.org/WAI/tutorials/carousels/), some new accessibility features have been implemented:

- Indicators are now focusable by default, since they are no longer simple list items, but buttons instead.
- Indicator text label (only detected by assistive technologies): It is possible to change the default label by setting a proper function in "indicatorLabelFunc" option;
- "Aria-controls" attribute to indicators/buttons;
- Slides are now automatically focused when its corresponding indicator has been selected;
- "Hidden" slides are no longer focused and are hidden to assistive technologies (full width carousel only).
- Every carousel must have a proper id, so, indicators are able to reference . Therefore a new id will be assigned to the carousel element on initialization if it does not have one yet.

**NB:** There are other aspects of an "accessible carousel" covered by W3C example which were not implemented here due to lack of escope (e.g.: our current implementation does not provide "autoplay" functionality (Slider should be used, instead)).

## Screenshots (if appropriate) or codepen:

![Screenshot of Firefox browser displaying a Carousel sample and its respective accessibility properties](https://user-images.githubusercontent.com/7539096/206875620-96e43c4e-bdb6-430d-8399-ee69dfc6df17.png "Carousel accessibility properties")

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
