### PR TITLE
Improve drop-down placement

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -562,7 +562,7 @@
 
       // Container here will be closest ancestor with overflow: hidden
       let closestOverflowParent = getClosestAncestor(this.dropdownEl, (ancestor) => {
-        return $(ancestor).css('overflow') !== 'visible';
+        return !$(ancestor).is('html,body') && $(ancestor).css('overflow') !== 'visible';
       });
       // Fallback
       if (!closestOverflowParent) {


### PR DESCRIPTION
## Proposed changes

In case the `body` or `html` element defines a `overflow` other than `visible`, drop-downs are currently misplaced.
As both elements are not relevant when trying to look for the best placement, this PR adds a check to ignore them.

Fixes https://github.com/materializecss/materialize/issues/311

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

see https://github.com/materializecss/materialize/issues/311

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
