### PR TITLE
fix conflict between sidenav drag and back gesture on Android

### DIFF
--- a/sass/components/_sidenav.scss
+++ b/sass/components/_sidenav.scss
@@ -149,7 +149,7 @@
   height: 100%;
   position: fixed;
   top: 0;
-  left: 0;
+  left: 40px;
   z-index: 998;
 }
 


### PR DESCRIPTION
## Proposed changes
This PR fixes freezing app when Back gesture occurred on Android.

When you swipe a page to get back to the previous page, the gesture also triggers dragging Sidenav because both share the same area (left: 0). That sets .sidenav-overlay to "display: block; opacity: 0" (should be display: none;...) and the page does not accept any user action. That's a show stopper.



This PR moves the position of .drag-target from "left: 0" to "left: 40px" to avoid the conflict.

```
.drag-target {
   left: 40px;
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
