### PR TITLE
fix: navbar-link, workflow and serve docs directly via grunt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             publish_dir: ./docs
+            cname: materializeweb.com
             exclude_assets: node_modules
             user_name: 'github-actions[bot]'
             user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -173,7 +173,7 @@ module.exports = function(grunt) {
       bsFiles: ['bin/*', 'css/ghpages-materialize.css', '!**/node_modules/**/*'],
       options: {
         server: {
-          baseDir: './' // make server from root dir
+          baseDir: './docs/' // make server from root dir
         },
         port: 8000,
         ui: {

--- a/pug/_navbar.pug
+++ b/pug/_navbar.pug
@@ -11,7 +11,7 @@ header
       i.material-icons menu
   ul#nav-mobile.sidenav.sidenav-fixed
     li(class="logo")
-      a#logo-container.brand-logo(href='/materialize/')
+      a#logo-container.brand-logo(href='/')
         object#front-page-logo(type='image/svg+xml', data='res/materialize.svg') Your browser does not support SVG
     li.version
       a.dropdown-trigger(href='#' data-target='version-dropdown') 1.2.2


### PR DESCRIPTION
## Proposed changes
- changed workflow to work with cname, otherwise gh-pages-workflow overwrites custom domain
- rootfolder of grunt to docs/
- navabarlink to root-folder (so it works on every domain)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
