### PR TITLE
Typescript classes for component options

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -1,20 +1,31 @@
 import { Component } from "./component";
+import { DropdownOptions } from "./dropdown";
 import { M } from "./global";
-import { Dropdown } from "./dropdown";
 
-let _defaults = {
+export interface AutocompleteOptions {
+  data?: any[];
+  onAutocomplete?(selectedValue: any): void;
+  maxDropDownHeight?: string;
+  dropdownOptions?: DropdownOptions;
+  minLength?: number;
+  isMultiSelect?: boolean;
+  onSearch?(text: string, autocomplete: Autocomplete, options: AutocompleteOptions):void;
+  allowUnsafeHTML?: boolean;
+}
+
+const _defaults: AutocompleteOptions = {
   data: [], // Autocomplete data set
-  onAutocomplete: null, // Callback for when autocompleted
   dropdownOptions: {
     // Default dropdown options
     autoFocus: false,
     closeOnClick: false,
     coverTrigger: false
   },
+  onAutocomplete: null,
   minLength: 1, // Min characters before autocomplete starts
   isMultiSelect: false,
-  onSearch: function(text, autocomplete) {
-    const filteredData = autocomplete.options.data.filter(item => {
+  onSearch: (text, autocomplete, options) => {
+    const filteredData = options.data.filter(item => {
       return Object.keys(item)
         .map(key => item[key].toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
         .some(isMatch => isMatch);
@@ -48,7 +59,7 @@ export class Autocomplete extends Component {
   menuItems: any[];
 
 
-  constructor(el, options) {
+  constructor(el, protected options: AutocompleteOptions) {
     super(Autocomplete, el, options);
     (this.el as any).M_Autocomplete = this;
     this.options = {...Autocomplete.defaults, ...options};
@@ -66,7 +77,7 @@ export class Autocomplete extends Component {
   static get defaults() {
     return _defaults;
   }
-  static init(els, options) {
+  static init(els, options: AutocompleteOptions) {
     return super.init(this, els, options);
   }
   static getInstance(el) {
@@ -203,7 +214,7 @@ export class Autocomplete extends Component {
     // Value has changed!
     if (this.oldVal !== actualValue) {
       this._setStatusLoading();
-      this.options.onSearch(this.el.value, this);
+      this.options.onSearch(this.el.value, this, this.options);
     }
     // Reset Single-Select when Input cleared
     if (!this.options.isMultiSelect && this.el.value.length === 0) {

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -2,6 +2,23 @@ import { Component } from "./component";
 import { M } from "./global";
 import anim from "animejs";
 
+  export interface DropdownOptions {    
+    alignment?: string;
+    autoFocus?: boolean;
+    constrainWidth?: boolean;
+    container?: any;
+    coverTrigger?: boolean;
+    closeOnClick?: boolean;
+    hover?: boolean;
+    inDuration?: number;
+    outDuration?: number;
+    onOpenStart?(elem: HTMLElement):void;
+    onOpenEnd?(elem: HTMLElement):void;
+    onCloseStart?(elem: HTMLElement):void;
+    onCloseEnd?(elem: HTMLElement):void;
+    onItemClick?(elem: HTMLElement):void;
+  }
+
   const _defaults = {
     alignment: 'left',
     autoFocus: true,
@@ -40,7 +57,7 @@ import anim from "animejs";
     private _handleClickBound: any;
     filterTimeout: NodeJS.Timeout;
 
-    constructor(el, options) {
+    constructor(el, protected options: DropdownOptions) {
       super(Dropdown, el, options);
       (this.el as any).M_Dropdown = this;
       Dropdown._dropdowns.push(this);


### PR DESCRIPTION
## Proposed changes
Add classes for component options. This will give typescript info of the available properties.
As an idea the options class can have a constructor of this kind:
```
constructor(init?: Partial<AutocompleteOptions>)
  {
    Object.assign(this, {..._defaults, ...init});         
  }
```
this will allow initialisations as 

`new AutocompleteOptions({minLength: 2})`

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
