### PR TITLE
fix: library does not load in webpack projects #364

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,8 +129,8 @@ module.exports = function(grunt) {
         output: {
           filename: 'materialize.js',
           path: path.resolve(__dirname, 'dist/js'),
-          libraryTarget: 'var',
-          library: 'M'
+          libraryTarget: 'umd',        
+          globalObject: 'this'          
         }
       }),
 
@@ -140,8 +140,8 @@ module.exports = function(grunt) {
         output: {
           filename: 'materialize.min.js',
           path: path.resolve(__dirname, 'dist/js'),
-          libraryTarget: 'var',
-          library: 'M'
+          libraryTarget: 'umd',        
+          globalObject: 'this'        
         }
       }),
     },       

--- a/src/global.ts
+++ b/src/global.ts
@@ -382,4 +382,4 @@ export class M {
   }
 }
 
-module.exports = M
+export default M;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,10 @@ module.exports = {
   output: {
     filename: 'materialize.js',
     path: path.resolve(__dirname, 'bin'),
-    libraryTarget: 'var',
-    library: 'M'
+    libraryTarget: 'umd',        
+    globalObject: 'this'
+  }, 
+  optimization: {
+    minimize: false,
   }
 };


### PR DESCRIPTION
## Proposed changes
Changed library export method to `export default M;` and the configuration of webpack output library to the options that has proved to work without breaking changes for existing doc pages and also for projects using the library in typescript classes and webpack for bundling.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- this can be tested with the webpack version of document that was linked in the issue description.
- It would be good to have some official demo of the library in a webpack project

- [x ] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x ] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
