### PR TITLE
fix: tabs not directly managing content

### DIFF
--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -104,7 +104,8 @@ export class Tabs extends Component {
       // Update the variables with the new link and content
 
       this._activeTabLink = tabLink;
-      this._content = document.querySelector(tabLink.hash);
+      if (tabLink.hash)
+        this._content = document.querySelector(tabLink.hash);
       this._tabLinks = this.el.querySelectorAll('li.tab > a');
       // Make the tab active
       this._activeTabLink.classList.add('active');
@@ -160,8 +161,8 @@ export class Tabs extends Component {
       this._activeTabLink.classList.add('active');
 
       this._index = Math.max(Array.from(this._tabLinks).indexOf(this._activeTabLink), 0);
-      if (this._activeTabLink) {
-        this._content = document.querySelector(this._activeTabLink.hash);
+      if (this._activeTabLink && this._activeTabLink.hash) {
+        this._content = document.querySelector(this._activeTabLink.hash);        
         this._content.classList.add('active');
       }
     }
@@ -173,9 +174,11 @@ export class Tabs extends Component {
 
       const tabsContent = [];
       this._tabLinks.forEach(a => {
-        const currContent = document.querySelector(a.hash);
-        currContent.classList.add('carousel-item');
-        tabsContent.push(currContent);
+        if (a.hash) {
+          const currContent = document.querySelector(a.hash);
+          currContent.classList.add('carousel-item');
+          tabsContent.push(currContent);  
+        }
       });
 
       // Create Carousel-Wrapper around Tab-Contents


### PR DESCRIPTION
## Proposed changes
For tabs component: minor changes (just empty checks) to maintain option to use only the tabs part, without managing the content associated to each tab. 
This was working in previous version just not defining the href  for each tab anchor elemento. 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
