### PR TITLE
Support to Material Symbols

### DIFF
--- a/pug/contents/chips_content.html
+++ b/pug/contents/chips_content.html
@@ -162,6 +162,12 @@
               <td>Set second placeholder when adding additional tags.</td>
             </tr>
             <tr>
+              <td>closeIconClass</td>
+              <td>String</td>
+              <td>'material-icons'</td>
+              <td>Specifies class to be used in "close" button (useful when working with Material Symbols icon set).</td>
+            </tr>
+            <tr>
               <td>autocompleteOptions</td>
               <td>Object</td>
               <td>{}</td>

--- a/pug/contents/icons_content.html
+++ b/pug/contents/icons_content.html
@@ -3,14 +3,26 @@
     <div class="col s12 m8 offset-m1 xl7 offset-xl1">
 
     <div id="usage" class="scrollspy">
-            <p class="caption">We use Google Material Icons by Google. They provide a <a href="https://jossef.github.io/material-design-icons-iconfont/">searchable list</a> (which we do not include in the documentation here), which will also show you the relevant icon names for the CSS classes. You can download the icons directly from the <a href="https://google.github.io/material-design-icons/#icon-font-for-the-web">Material Design specs</a>.</p>
+            <p class="caption">We use Google Material Icons by Google. They provide a <a href="https://fonts.google.com/icons?icon.set=Material+Icons">searchable list</a> (which we do not include in the documentation here), which will also show you the relevant icon names for the CSS classes. You can download the icons directly from the <a href="https://google.github.io/material-design-icons/#icon-font-for-the-web">Material Design specs</a>.</p>
+            <p class="caption">In addition to Material Icons, we also provide support to every variation of <a href="https://fonts.google.com/icons?icon.set=Material+Symbols">Material Symbols</a> set (outlined, rounded and sharp).</p>
             <h3 class="header">Usage</h3>
-            <p>To be able to use these icons, you must include this line in the <code class="language-markup">&lt;head></code>portion of your HTML code</p>
+            <p>To be able to use these icons, you must include one of the following lines in the <code class="language-markup">&lt;head></code>portion of your HTML code</p>
             <pre><code class="language-markup">
-  &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet"></code></pre>
-            <p>To use these icons, use the material-icons class on an element and provide the ligature as the text content.</p>
+  &lt;-- Material Icons --&gt;
+  &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+  &lt;-- Material Symbols - Outlined Set --&gt;
+  &lt;link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  &lt;-- Material Symbols - Rounded Set --&gt;
+  &lt;link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded" rel="stylesheet" />
+  &lt;-- Material Symbols - Sharp Set --&gt;
+  &lt;link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp" rel="stylesheet" /></code></pre>
+            <p>To use these icons, use either the material-icons class or the corresponding material-symbols set class on an element and provide the ligature as the text content.</p>
             <pre><code class="language-markup">
   &lt;i class="material-icons">add&lt;/i>
+  &lt;-- Use one of the following if opted by material symbols --&gt;
+  &lt;i class="material-symbols-outlined">add&lt;/i>
+  &lt;i class="material-symbols-rounded">add&lt;/i>
+  &lt;i class="material-symbols-sharp">add&lt;/i>
             </code></pre>
 
             <h5>Sizes</h5>
@@ -34,7 +46,12 @@
   medium: 4rem
   large: 6rem
   -->
+  &lt;-- Material Icons --&gt;
   &lt;i class="large material-icons">insert_chart&lt;/i>
+  &lt;-- Material Symbols --&gt;
+  &lt;i class="large material-symbols-outlined">insert_chart&lt;/i>
+  &lt;i class="large material-symbols-rounded">insert_chart&lt;/i>
+  &lt;i class="large material-symbols-sharp">insert_chart&lt;/i>
             </code></pre>
         </div>
     </div>
@@ -47,7 +64,8 @@
         <div style="height: 1px;">
           <ul class="section table-of-contents">
             <li><a href="#usage">Usage</a></li>
-            <li><a href="https://jossef.github.io/material-design-icons-iconfont/">Search Google's Icons</a></li>
+            <li><a href="https://fonts.google.com/icons?icon.set=Material+Icons">Search Google's Material Icons</a></li>
+            <li><a href="https://fonts.google.com/icons?icon.set=Material+Symbols">Search Google's Material Symbols</a></li>
           </ul>
         </div>
       </div>

--- a/sass/_style.scss
+++ b/sass/_style.scss
@@ -530,7 +530,8 @@ $height: auto;
 }
 
 // Icons
-.material-icons.icon-demo {
+.material-icons.icon-demo, .material-symbols-outlined.icon-demo,
+.material-symbols-rounded.icon-demo, .material-symbols-sharp.icon-demo {
   line-height: 50px;
 }
 
@@ -886,7 +887,8 @@ body.parallax-demo footer {
       height: 32px;
     }
 
-    i.material-icons {
+    i.material-icons, i.material-symbols-outlined,
+    i.material-symbols-rounded, i.material-symbols-sharp {
       position: absolute;
       top: 4px;
       right: 34px;

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -210,7 +210,8 @@ video.responsive-video {
 
   i,
   [class^="mdi-"], [class*="mdi-"],
-  i.material-icons {
+  i.material-icons, i.material-symbols-outlined,
+  i.material-symbols-rounded, i.material-symbols-sharp {
     display: block;
     float: left;
     font-size: 24px;
@@ -221,7 +222,7 @@ video.responsive-video {
     color: $font-on-primary-color-medium;
     vertical-align: top;
     display: inline-block;
-    font-family: 'Material Icons';
+    font-family: 'Material Symbols Outlined', 'Material Symbols Rounded', 'Material Symbols Sharp', 'Material Icons';
     font-weight: normal;
     font-style: normal;
     font-size: 25px;

--- a/sass/components/_icons-material-design.scss
+++ b/sass/components/_icons-material-design.scss
@@ -1,5 +1,6 @@
 /* This is needed for some mobile phones to display the Google Icon font properly */
-.material-icons {
+.material-icons, .material-symbols-outlined,
+.material-symbols-rounded, .material-symbols-sharp {
   text-rendering: optimizeLegibility;
   font-feature-settings: 'liga';
 }

--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -27,7 +27,8 @@ nav {
 
   i,
   [class^="mdi-"], [class*="mdi-"],
-  i.material-icons {
+  i.material-icons, i.material-symbols-outlined,
+  i.material-symbols-rounded, i.material-symbols-sharp {
     display: block;
     font-size: 24px;
     height: $navbar-height-mobile;
@@ -97,7 +98,8 @@ nav {
 
     i,
     [class^="mdi-"], [class*="mdi-"],
-    i.material-icons {
+    i.material-icons, i.material-symbols-outlined,
+    i.material-symbols-rounded, i.material-symbols-sharp {
       float: left;
       margin-right: 15px;
     }
@@ -145,7 +147,8 @@ nav {
         margin-right: 15px;
         display: inline-block;
 
-        & > .material-icons {
+        & > .material-icons, & > .material-symbols-outlined,
+        & > .material-symbols-rounded, & > .material-symbols-sharp {
           height: inherit;
           line-height: inherit;
         }

--- a/sass/components/_sidenav.scss
+++ b/sass/components/_sidenav.scss
@@ -59,7 +59,8 @@
 
     & > i,
     & > [class^="mdi-"], li > a > [class*="mdi-"],
-    & > i.material-icons {
+    & > i.material-icons, & > i.material-symbols-outlined,
+    & > i.material-symbols-rounded, & > i.material-symbols-sharp {
       float: left;
       height: $sidenav-item-height;
       line-height: $sidenav-line-height;

--- a/src/chips.ts
+++ b/src/chips.ts
@@ -6,6 +6,7 @@ let _defaults = {
   data: [],
   placeholder: '',
   secondaryPlaceholder: '',
+  closeIconClass: 'material-icons',
   autocompleteOptions: {},
   autocompleteOnly: false,
   limit: Infinity,
@@ -231,7 +232,7 @@ export class Chips extends Component {
     renderedChip.innerText = chip.text || chip.id;
     renderedChip.setAttribute('tabindex', "0");
     const closeIcon = document.createElement('i');
-    closeIcon.classList.add('material-icons', 'close');
+    closeIcon.classList.add(this.options.closeIconClass, 'close');
     closeIcon.innerText = 'close';
     // attach image if needed
     if (chip.image) {


### PR DESCRIPTION
## Proposed changes

Add support to "[material-symbols](https://material.io/blog/introducing-symbols)", the newest alternative to "material icons".

What is new:

- Possibility of using any set of "[material-symbols](https://fonts.google.com/icons?icon.set=Material+Symbols)" (outlined, round or sharp) where "material-icons" can be used;
- Chips can receive a custom "closeIconClass" property if the user wants to use "symbols" instead of "icons" (defaults to "icons");
- Updated docs so as to include samples in "Icons" page and "closeIconClass" Chips property description:
    - Updated link to "Material Icons" (official font reference page);
    - Included link to "Material Symbols" (official font reference page);
    - Added code samples.
- "font-family" prioritizes "Material Symbols" falling back to "Material Icons", if not found.

## Screenshots (if appropriate) or codepen:

In the following screenshot it is possible to check the usage of a Material Symbol (database) which is not present in "Material Icons" (iconset):

![Screenshot of the "database" symbol in different sizes: tiny, small, medium and large](https://github.com/materializecss/materialize/assets/7539096/10e4e6d2-274f-4306-971e-2129f341d947)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
