### PR TITLE
Allow "valid" placeholders for form inputs

### DIFF
--- a/pug/contents/text_inputs_content.html
+++ b/pug/contents/text_inputs_content.html
@@ -124,17 +124,46 @@
     &lt;/form>
   &lt;/div>
         </code></pre>
-        <h5>Floating Labels with CSS only</h5>
-        <p>There should not be any problems with initializing the inputs properly, since the floating Labels are rendered with CSS only. The CSS Technique requires to use an empty placeholder in the HTML. You have to put an emtpy space in the placeholder. Putting an empty string wont work.</p>
-          <div class="input-field outline">
-            <input value="Daniel" id="first_name2" type="text" class="validate" placeholder=" ">
-            <label class="active" for="first_name2">First Name</label>
+        <h5 id="floating-labels">Floating Labels</h5>
+        <p>
+          Since <b>MaterializeCSS v2</b>, floating Labels are rendered with CSS only by default.
+          However, it is required to use a placeholder with a single white space (" ") in the HTML
+          (providing an empty string will not work!).
+        </p>
+        <p>
+          <strong><b>Important:</b></strong> If you provide a value different than a single white space,
+          the CSS rules will treat it as a "important" placeholder value and will always render the
+          labels in "active" state.
+        </p>
+          <div class="row">
+            <div class="col s12 m6">
+              <div class="input-field outlined" style="margin: 0 4px;">
+                <input id="first_name2" type="text" class="validate" placeholder=" ">
+                <label class="active" for="first_name2">First Name</label>
+              </div>
+            </div>
+            <div class="col s12 m6">
+              <div class="input-field outlined" style="margin: 0 4px;">
+                <input id="last_name2" type="text" class="validate" placeholder="Doe...">
+                <label class="active" for="last_name2">Last Name</label>
+              </div>
+            </div>
           </div>
 
         <pre><code class="language-markup">
-&lt;div class="input-field">
-  &lt;input value="Daniel" id="first_name2" type="text" class="validate" placeholder=" ">
-  &lt;label class="active" for="first_name2">First Name&lt;/label>
+&lt;div class="row">
+  &lt;div class="col s12 m6">
+    &lt;div class="input-field outlined" style="margin: 0 4px;">
+      &lt;input id="first_name2" type="text" class="validate" placeholder=" ">
+      &lt;label class="active" for="first_name2">First Name&lt;/label>
+    &lt;/div>
+  &lt;/div>
+  &lt;div class="col s12 m6">
+    &lt;div class="input-field outlined" style="margin: 0 4px;">
+      &lt;input id="last_name2" type="text" class="validate" placeholder="Doe...">
+      &lt;label class="active" for="last_name2">Last Name&lt;/label>
+    &lt;/div>
+  &lt;/div>
 &lt;/div>
         </code></pre>
 

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -89,6 +89,7 @@ textarea.materialize-textarea {
       color: $input-focus-color;
     }
     &:focus:not([readonly]) + label,
+    &:not([placeholder=' ']) + label,
     &:not(:placeholder-shown) + label {
       //font-size: 12px; // md.sys.typescale.body-small.size
       // https://stackoverflow.com/questions/34717492/css-transition-font-size-avoid-jittering-wiggling
@@ -187,6 +188,7 @@ textarea.materialize-textarea {
         color: $input-focus-color;
       }
       &:focus:not([readonly]) + label,
+      &:not([placeholder=' ']) + label,
       &:not(:placeholder-shown) + label {
         top: -8px;
         left: 16px;


### PR DESCRIPTION
## Proposed changes

With the new proposal of "CSS only" floating labels, it was not possible to use placeholders as "valid" input hints. Therefore, this PR aims to force the users to provide only a single white space (`" "`) for placeholder attribute in floating label inputs, or the labels will be "always active", allowing "useful placeholders" to be displayed (see screenshots below).

Summary:

- Inputs with floating labels must have a single white space (`" "`) as placeholder value;
- Inputs with placeholder values other than a single whitespace will always render their respective labels in "active" state;
- Updated docs so as to make it clear and reflect changes 😄.

## Screenshots (if appropriate) or codepen:

### Previous behaviour

Input labels overlaps "useful" placeholder values.

![Form fields with valid placeholder values being overlaped by their respective labels](https://github.com/materializecss/materialize/assets/7539096/f658837f-47e5-4841-bf10-dd25b338aa22)

### Current behaviour

Input labels are corectly rendered when "useful" placeholder values are provided.

![Form fields with valid placeholder values being correcly rendered](https://github.com/materializecss/materialize/assets/7539096/3e771b25-180d-4f2a-9014-544021322c32)


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
