### PR TITLE
Support to "Shadow DOM"

### DIFF
--- a/sass/components/_theme_variables.scss
+++ b/sass/components/_theme_variables.scss
@@ -1,4 +1,4 @@
-:root {
+:root, :host {
     --surface-color: #f3f6fc;
     --background-color: #ffffff;
 
@@ -53,7 +53,7 @@
     --md_sys_color_on-surface: 28, 27, 31;
 }
 
-:root[theme='dark'] {
+:root[theme='dark'], :host[theme='dark'] {
     --background-color: #121212;
     --surface-color: #242424;
 


### PR DESCRIPTION
## Proposed changes

Made "CSS" variables compatible with custom elements (shadow dom).

This PR aims to close #329.

## Screenshots (if appropriate) or codepen:

It is possible to check the current behaviour in [this pen](https://codepen.io/Canabale/pen/jOQWEzK) provided at #329.

With this "fix", the inputs should render correcly:

![Form input element being correctly rendered](https://github.com/materializecss/materialize/assets/7539096/6c7fa163-ee02-4c84-a5ae-86c8e9e39d26)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
