### PR TITLE
Replacement for standard search function in autocomplete

### DIFF
--- a/pug/contents/autocomplete_content.html
+++ b/pug/contents/autocomplete_content.html
@@ -51,9 +51,38 @@
 
       <div id="initialization" class="scrollspy section">
         <h3 class="header">Initialization</h3>
-        <p>The data is a json object where the key is the matching string and the value is an optional image url.</p>
-        <p>The key must be a text string. If you trust your data, or have properly sanitized your user input, you may
-          use HTML by setting the option <code class="language-javascript">allowUnsafeHTML: true</code>.</p>
+        <p>The data is an array of option objects, which supports three different attributes:</p>
+        <p>
+          <ul class="collection">
+            <li class="collection-item">
+              <p style="margin: 0;">
+                <b>id</b>: This is the only mandatory attribute: it must be a primitive value that can be
+                  converted to string. If "text" is not provided, it will also be used as "option text" as well;
+              </p>
+            </li>
+            <li class="collection-item">
+              <p style="margin: 0;">
+                <b>text</b>: This optional attribute is used as "display value" for the current entry.
+                  When provided, it will also be taken into consideration by the standard search function.
+              </p>
+              <P style="margin: 0;">
+                If you trust your data or have properly sanitized your user input, you may use
+                  use HTML by setting the option <code class="language-javascript">allowUnsafeHTML: true</code>;
+              </P>
+            </li>
+            <li class="collection-item">
+              <p style="margin: 0;">
+                <b>image</b>: This optional attribute is used to provide a valid image URL to the current option.
+                  This attribute is ignored by the standard search function.
+              </p>
+            </li>
+          </ul>
+        </p>
+        <p>
+          You may also provide additional attributes to an option object but they will not be taken into
+          consideration by the standard search function. If you want to use them for option filtering, you
+          must specify a custom function in "<b>onSearch</b>" option.
+        </p>
           <pre style="padding-top: 0px;">
             <span class="copyMessage">Copied!</span>
             <i class="material-icons copyButton">content_copy</i>
@@ -99,7 +128,8 @@
         {id: 13, text: "Microsoft"},
         {id: 42, text: "Google", image: 'http://placehold.it/250x250'}
       ],
-      onSearch: function(text, autocomplete) {
+      // This search function considers every object entry as "search values".
+      onSearch: (text, autocomplete) => {
         const filteredData = autocomplete.options.data.filter(item => {
           return Object.keys(item)
             .map(key => item[key].toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
@@ -188,13 +218,14 @@
             <span class="copyMessage">Copied!</span>
             <i class="material-icons copyButton">content_copy</i>
             <code class="language-javascript copiedText">
-onSearch: function(text, autocomplete) {
-  const filteredData = autocomplete.options.data.filter(item => {
-    return Object.keys(item)
-      .map(key => item[key].toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
-      .some(isMatch => isMatch);
-  });
-  autocomplete.setMenuItems(filteredData);
+onSearch: (text, autocomplete) => {
+  const normSearch = text.toLocaleLowerCase();
+  autocomplete.setMenuItems(
+    autocomplete.options.data.filter((option) => 
+      option.id.toString().toLocaleLowerCase().includes(normSearch)
+        || option.text?.toLocaleLowerCase().includes(normSearch)
+    )
+  );
 }
 </code>
           </pre>

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -13,13 +13,14 @@ let _defaults = {
   },
   minLength: 1, // Min characters before autocomplete starts
   isMultiSelect: false,
-  onSearch: function(text, autocomplete) {
-    const filteredData = autocomplete.options.data.filter(item => {
-      return Object.keys(item)
-        .map(key => item[key].toString().toLowerCase().indexOf(text.toLowerCase()) >= 0)
-        .some(isMatch => isMatch);
-    });
-    autocomplete.setMenuItems(filteredData);
+  onSearch: (text: string, autocomplete) => {
+    const normSearch = text.toLocaleLowerCase();
+    autocomplete.setMenuItems(
+      autocomplete.options.data.filter((option) => 
+        option.id.toString().toLocaleLowerCase().includes(normSearch)
+          || option.text?.toLocaleLowerCase().includes(normSearch)
+      )
+    );
   },
   maxDropDownHeight: '300px',
   allowUnsafeHTML: false
@@ -175,7 +176,7 @@ export class Autocomplete extends Component {
   _handleInputKeyupAndFocus = (e: KeyboardEvent) => {
     if (e.type === 'keyup') Autocomplete._keydown = false;
     this.count = 0;
-    const actualValue = this.el.value.toLowerCase();
+    const actualValue = this.el.value.toLocaleLowerCase();
     // Don't capture enter or arrow key usage.
     if (M.keys.ENTER.includes(e.key) || M.keys.ARROW_UP.includes(e.key) || M.keys.ARROW_DOWN.includes(e.key)) return;
     // Check if the input isn't empty
@@ -254,7 +255,7 @@ export class Autocomplete extends Component {
   }
 
   _highlightPartialText(input, label) {
-    const start = label.toLowerCase().indexOf('' + input.toLowerCase() + '');
+    const start = label.toLocaleLowerCase().indexOf('' + input.toLocaleLowerCase() + '');
     const end = start + input.length - 1;
     //custom filters may return results where the string does not match any part
     if (start == -1 || end == -1) {
@@ -288,7 +289,7 @@ export class Autocomplete extends Component {
     }
 
     // Text
-    const inputText = this.el.value.toLowerCase();
+    const inputText = this.el.value.toLocaleLowerCase();
     const parts = this._highlightPartialText(inputText, (entry.text || entry.id).toString());
     const div = document.createElement('div');
     div.setAttribute('style', 'line-height:1.2;font-weight:500;');
@@ -378,7 +379,7 @@ export class Autocomplete extends Component {
   }
 
   open() {
-    const inputText = this.el.value.toLowerCase();
+    const inputText = this.el.value.toLocaleLowerCase();
     this._resetAutocomplete();
     if (inputText.length >= this.options.minLength) {
       this.isOpen = true;


### PR DESCRIPTION
## Proposed changes

The current implementation of "onSearch" callback considers every option element when filtering, which causes undesired options to be displayed for autocompletion (see attached screenshots).

This PR aims to replace the current standard search function that should consider only the "id" and "text" attributes, if available, when filtering the given options.

Summary:

- Enhancements in standard search function:
    - It now considers only the "id" and "text" attributes;
    - Localized "lowercase" (better internationalization);
    - Standard search still does not takes "text" into consideration if it is not provided;
    - Reduced algorithmic complexity (no longer makes two iterations over the array and does not consider every option entry).
- Docs:
    - Removed references to "old data type";
    - Added descriptions for option "id", "text" and "image" attributes;
    - Replaced sample implementation of standard search function.

## Screenshots (if appropriate) or codepen:

### Current behaviour

It displays "google" as a option, even though the word does not have an "a" on its spelling (it is possible to reproduce it in the [current version of the docs](https://materializeweb.com/autocomplete.html) 😞).

![Autocomplete considers "Google" as valid suggestion when "a" is typed](https://github.com/materializecss/materialize/assets/7539096/ff7970a2-09a7-4904-b1b8-0f9a71b29795)

### Autocomplete with new "standard search" implementation

![Autocomplete considers only "Apple" as valid suggestion when "a" is typed](https://github.com/materializecss/materialize/assets/7539096/97882666-b944-4d87-9254-c0a51c020492)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
