### PR TITLE
fix: avoid overwritting of base property 'el' in 'Component'

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -27,7 +27,7 @@ let _defaults = {
 
 
 export class Autocomplete extends Component {
-  el: HTMLInputElement;
+  declare el: HTMLInputElement;
   isOpen: boolean;
   count: number;
   activeIndex: number;

--- a/src/buttons.ts
+++ b/src/buttons.ts
@@ -8,7 +8,7 @@ let _defaults = {
 };
 
 export class FloatingActionButton extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   isOpen: boolean;
   private _anchor: HTMLAnchorElement;
   private _menu: HTMLElement|null;

--- a/src/carousel.ts
+++ b/src/carousel.ts
@@ -14,7 +14,7 @@ let _defaults = {
 };
 
 export class Carousel extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   hasMultipleSlides: boolean;
   showIndicators: boolean;
   noWrap: any;

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -89,7 +89,7 @@ let _defaults = {
 };
 
 export class Datepicker extends Component {
-  el: HTMLInputElement
+  declare el: HTMLInputElement;
   id: string;
   isOpen: boolean;
   modal: Modal;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -20,7 +20,7 @@ const _defaults = {
 };
 
 export class Dropdown extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   static _dropdowns: Dropdown[] = [];
   id: string;
   dropdownEl: HTMLElement;

--- a/src/materialbox.ts
+++ b/src/materialbox.ts
@@ -12,7 +12,7 @@ const _defaults = {
 };
 
 export class Materialbox extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   overlayActive: boolean;
   doneAnimating: boolean;
   caption: string;

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -17,7 +17,7 @@ const _defaults = {
 };
 
 export class Modal extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   static _modalsOpen: number;
   static _count: number;
   isOpen: boolean;

--- a/src/range.ts
+++ b/src/range.ts
@@ -6,7 +6,7 @@ const _defaults = {};
 // TODO: !!!!!
 
 export class Range extends Component {
-  el: HTMLInputElement;
+  declare el: HTMLInputElement;
   private _mousedown: boolean;
   value: HTMLElement;
   thumb: HTMLElement;

--- a/src/scrollspy.ts
+++ b/src/scrollspy.ts
@@ -10,7 +10,7 @@ let _defaults = {
 };
 
 export class ScrollSpy extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   static _elements: ScrollSpy[];
   static _count: number;
   static _increment: number;

--- a/src/select.ts
+++ b/src/select.ts
@@ -13,7 +13,7 @@ type ValueStruct = {
 }
 
 export class FormSelect extends Component {
-  el: HTMLSelectElement;
+  declare el: HTMLSelectElement;
   isMultiple: boolean;
   private _values: ValueStruct[];
   labelEl: HTMLLabelElement;

--- a/src/slider.ts
+++ b/src/slider.ts
@@ -13,7 +13,7 @@ let _defaults = {
 };
 
 export class Slider extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   _slider: HTMLUListElement;
   _slides: HTMLLIElement[];
   activeIndex: number;

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -10,7 +10,7 @@ let _defaults = {
 };
 
 export class Tabs extends Component {
-  el: HTMLElement;
+  declare el: HTMLElement;
   _tabLinks: any;
   _index: number;
   _indicator: any;

--- a/src/tapTarget.ts
+++ b/src/tapTarget.ts
@@ -7,7 +7,7 @@ let _defaults = {
 };
 
 export class TapTarget extends Component {
-  el: HTMLElement
+  declare el: HTMLElement;
   isOpen: boolean;
   private wrapper: HTMLElement;
   private _origin: HTMLElement;

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -35,7 +35,7 @@ type Point = {
 };
 
 export class Timepicker extends Component {
-  el: HTMLInputElement;
+  declare el: HTMLInputElement;
   id: string;
   modal: Modal;
   modalEl: HTMLElement;


### PR DESCRIPTION
## Proposed changes
Avoid the typescript error
` TS2612: Property 'el' will overwrite the base property in 'Component'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.`

## Types of changes
Adding 'declare' property modificator.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
