### PR TITLE
Fix textarea padding

### DIFF
--- a/pug/contents/text_inputs_content.html
+++ b/pug/contents/text_inputs_content.html
@@ -319,8 +319,14 @@
           <form class="col s12">
             <div class="row">
               <div class="input-field col s12">
-                <textarea id="textarea1" class="materialize-textarea"></textarea>
+                <textarea id="textarea1" class="materialize-textarea" placeholder=" "></textarea>
                 <label for="textarea1">Textarea</label>
+              </div>
+            </div>
+            <div class="row">
+              <div class="input-field col s12">
+                <textarea id="textarea2" class="materialize-textarea" placeholder="A custom placeholder :)"></textarea>
+                <label for="textarea2">Textarea with placeholder</label>
               </div>
             </div>
           </form>
@@ -330,8 +336,14 @@
     &lt;form class="col s12">
       &lt;div class="row">
         &lt;div class="input-field col s12">
-          &lt;textarea id="textarea1" class="materialize-textarea">&lt;/textarea>
+          &lt;textarea id="textarea1" class="materialize-textarea" placeholder=" ">&lt;/textarea>
           &lt;label for="textarea1">Textarea&lt;/label>
+        &lt;/div>
+      &lt;/div>
+      &lt;div class="row">
+        &lt;div class="input-field col s12">
+          &lt;textarea id="textarea2" class="materialize-textarea" placeholder="A custom placeholder :)">&lt;/textarea>
+          &lt;label for="textarea2">Textarea with placeholder&lt;/label>
         &lt;/div>
       &lt;/div>
     &lt;/form>
@@ -351,7 +363,7 @@
             <div class="row">
               <div class="input-field col s12">
                 <i class="material-icons prefix">mode_edit</i>
-                <textarea id="icon_prefix2" class="materialize-textarea"></textarea>
+                <textarea id="icon_prefix2" class="materialize-textarea" placeholder=" "></textarea>
                 <label for="icon_prefix2">Message</label>
               </div>
             </div>
@@ -444,13 +456,13 @@
           <form class="col s12">
             <div class="row">
               <div class="input-field col s6">
-                <input id="input_text" type="text" maxlength="10">
+                <input id="input_text" type="text" maxlength="10" placeholder=" ">
                 <label for="input_text">Input text</label>
               </div>
             </div>
             <div class="row">
               <div class="input-field col s12">
-                <textarea id="textarea2" class="materialize-textarea" maxlength="120"></textarea>
+                <textarea id="textarea2" class="materialize-textarea" maxlength="120" placeholder=" "></textarea>
                 <label for="textarea2">Textarea</label>
               </div>
             </div>
@@ -461,13 +473,13 @@
       &lt;form class="col s12">
         &lt;div class="row">
           &lt;div class="input-field col s6">
-            &lt;input id="input_text" type="text" maxlength="10">
+            &lt;input id="input_text" type="text" maxlength="10" placeholder=" ">
             &lt;label for="input_text">Input text&lt;/label>
           &lt;/div>
         &lt;/div>
         &lt;div class="row">
           &lt;div class="input-field col s12">
-            &lt;textarea id="textarea2" class="materialize-textarea" maxlength="120">&lt;/textarea>
+            &lt;textarea id="textarea2" class="materialize-textarea" maxlength="120" placeholder=" ">&lt;/textarea>
             &lt;label for="textarea2">Textarea&lt;/label>
           &lt;/div>
         &lt;/div>

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -284,9 +284,10 @@ textarea {
   background-color: transparent;
 
   &.materialize-textarea {
+    padding-top: 26px !important;
+    padding-bottom: 4px !important;
     line-height: normal;
     overflow-y: hidden; /* prevents scroll bar flash */
-    padding: .8rem 0 .8rem 0; /* prevents text jump on Enter keypress */
     resize: none;
     min-height: $input-height;
     box-sizing: border-box;


### PR DESCRIPTION
## Proposed changes

Fix textarea padding which is currently not being inherited from "default input styles".

The textarea content is being currently overlaped by its label when not active and zero-padded in every context (focused/not focused).

Summary:

- Fixed stylesheet rules (`padding` in `materialize-texarea` class);
- Added new sample for textarea with custom placeholder;
- Added placeholder for textarea samples (enable floating label).

## Screenshots (if appropriate) or codepen:

### Current behaviour

Focused:
![Focused textarea with content](https://github.com/materializecss/materialize/assets/7539096/b304b33c-f14c-4699-b82f-578da0fdd20d)

Not focused:
![Textarea with content, but without focus](https://github.com/materializecss/materialize/assets/7539096/5a319609-3e87-45a8-aaf7-3e12f1fe7434)

### New behaviour

Focused:
![Focused textarea with content](https://github.com/materializecss/materialize/assets/7539096/defabda8-48bc-4f7f-bc84-8f69c4de32e3)

Not focused:
![Textarea with content, but without focus](https://github.com/materializecss/materialize/assets/7539096/0b02a42c-f637-4356-a601-48f8f95e03fa)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
