### PR TITLE
fix(pulse): decorative pulse

### DIFF
--- a/sass/components/_pulse.scss
+++ b/sass/components/_pulse.scss
@@ -3,6 +3,7 @@
     content: '';
     display: block;
     position: absolute;
+    pointer-events: none;
     width: 100%;
     height: 100%;
     top: 0;


### PR DESCRIPTION
## Proposed changes

Pulse will no longer receive pointer events:

- Pulse will only act as a decorative element.

This should close #326.

## Screenshots (if appropriate) or codepen:

Screenshots already provided in #326.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
