### PR TITLE
fix(all dispatchevent on components): make event propageable to work…

### DIFF
--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -463,7 +463,7 @@ export class Datepicker extends Component<DatepickerOptions> {
    */
   setInputValue() {
     this.el.value = this.toString();
-    this.el.dispatchEvent(new CustomEvent('change', {detail: {firedBy: this}}));
+    this.el.dispatchEvent(new CustomEvent('change', {bubbles:true, cancelable:true, composed:true, detail: {firedBy: this}}));
   }
 
   _renderDateDisplay() {

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -114,7 +114,7 @@ export class Forms {
             filenames.push(files[i].name);
           }
           pathInput.value = filenames.join(', ');
-          pathInput.dispatchEvent(new Event('change'));
+          pathInput.dispatchEvent(new Event('change',{bubbles:true, cancelable:true, composed:true}));
         });
       });
 

--- a/src/select.ts
+++ b/src/select.ts
@@ -160,7 +160,7 @@ export class FormSelect extends Component<FormSelectOptions> {
         previousSelectedValues,
         actualSelectedValues
       );
-      if (selectionHasChanged) this.el.dispatchEvent(new Event('change')); // trigger('change');
+      if (selectionHasChanged) this.el.dispatchEvent(new Event('change',{bubbles:true, cancelable:true, composed:true})); // trigger('change');
     }
     if (!this.isMultiple) this.dropdown.close();
   }

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -792,7 +792,7 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.el.value = value;
     // Trigger change event
     if (value !== last) {
-      this.el.dispatchEvent(new Event('change'));
+      this.el.dispatchEvent(new Event('change',{bubbles:true, cancelable:true, composed:true}));
     }
     this.close();
     this.el.focus();


### PR DESCRIPTION
… with framework (e.g react)

Actualy materialize is broken on react and ember js due to non propageable event for e.g react overload default onchange event with onChange custom event since alpha release materialize not fired event due to non propageable event on components

fix  #398

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
