### PR TITLE
Add functions to initialize textarea and the File Input Path created programmatically

### DIFF
--- a/pug/contents/text_inputs_content.html
+++ b/pug/contents/text_inputs_content.html
@@ -354,8 +354,8 @@
         <pre><code class="language-javascript">  M.Forms.InitTextarea(document.querySelector('#textarea1'));</code></pre>
         <p>When dynamically changing the value of a textarea like setting <code class="language-markup">HTMLElement#value</code> attribute, you must trigger an autoresize on it afterwords because simply updating the element's value does not automatically trigger the events we've binded to the textarea.</p>
         <pre><code class="language-javascript">
-            document.querySelector("#textarea1").value = 'New Text';
-            M.Forms.textareaAutoResize(document.querySelector('#textarea1'));
+  document.querySelector("#textarea1").value = 'New Text';
+  M.Forms.textareaAutoResize(document.querySelector('#textarea1'));
         </code></pre>
         
 

--- a/pug/contents/text_inputs_content.html
+++ b/pug/contents/text_inputs_content.html
@@ -349,10 +349,13 @@
     &lt;/form>
   &lt;/div>
         </code></pre>
-        <p><strong><b>Advanced note:</b></strong> When dynamically changing the value of a textarea like setting <code class="language-markup">HTMLElement#value</code> attribute, you must trigger an autoresize on it afterwords because simply updating the element's value does not automatically trigger the events we've binded to the textarea.</p>
+        <p><strong><b>Advanced notes:</b></strong> </p>
+        <p>If you are adding Textarea form elements dynamically, you can use this to initialize them.</p>
+        <pre><code class="language-javascript">  M.Forms.InitTextarea(document.querySelector('#textarea1'));</code></pre>
+        <p>When dynamically changing the value of a textarea like setting <code class="language-markup">HTMLElement#value</code> attribute, you must trigger an autoresize on it afterwords because simply updating the element's value does not automatically trigger the events we've binded to the textarea.</p>
         <pre><code class="language-javascript">
-  document.querySelector("#textarea1").value = 'New Text';
-  M.Forms.textareaAutoResize(document.querySelector('#textarea1'));
+            document.querySelector("#textarea1").value = 'New Text';
+            M.Forms.textareaAutoResize(document.querySelector('#textarea1'));
         </code></pre>
         
 
@@ -439,6 +442,10 @@
     &lt;/div>
   &lt;/form>
         </code></pre>
+
+      <p><strong><b>Advanced note:</b></strong> </p>
+        <p>If you are adding File Input form elements dynamically, you can use this to initialize them.</p>
+        <pre><code class="language-javascript">  M.Forms.InitFileInputPath(document.querySelector('#fileinput1'));</code></pre>
       </div>
 
 

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -94,13 +94,7 @@ export class Forms {
       });
 
       document.querySelectorAll('.materialize-textarea').forEach((textArea: HTMLTextAreaElement) => {
-        // Save Data in Element
-        textArea.setAttribute('original-height', textArea.getBoundingClientRect().height.toString());
-        textArea.setAttribute('previous-length', textArea.value.length.toString());
-        Forms.textareaAutoResize(textArea);
-
-        textArea.addEventListener('keyup', e => Forms.textareaAutoResize(textArea));
-        textArea.addEventListener('keydown', e => Forms.textareaAutoResize(textArea));
+          Forms.textareaAutoResize(textArea);
       });
 
       // File Input Path
@@ -120,4 +114,15 @@ export class Forms {
 
     });
   }
+
+  static InitTextarea(textarea: HTMLTextAreaElement){
+        // Save Data in Element
+        textArea.setAttribute('original-height', textArea.getBoundingClientRect().height.toString());
+        textArea.setAttribute('previous-length', textArea.value.length.toString());
+        Forms.textareaAutoResize(textArea);
+
+        textArea.addEventListener('keyup', e => Forms.textareaAutoResize(textArea));
+        textArea.addEventListener('keydown', e => Forms.textareaAutoResize(textArea));
+  }
+  
 }

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -117,12 +117,12 @@ export class Forms {
 
   static InitTextarea(textarea: HTMLTextAreaElement){
         // Save Data in Element
-        textArea.setAttribute('original-height', textArea.getBoundingClientRect().height.toString());
-        textArea.setAttribute('previous-length', textArea.value.length.toString());
-        Forms.textareaAutoResize(textArea);
+        textarea.setAttribute('original-height', textarea.getBoundingClientRect().height.toString());
+        textarea.setAttribute('previous-length', textarea.value.length.toString());
+        Forms.textareaAutoResize(textarea);
 
-        textArea.addEventListener('keyup', e => Forms.textareaAutoResize(textArea));
-        textArea.addEventListener('keydown', e => Forms.textareaAutoResize(textArea));
+        textarea.addEventListener('keyup', e => Forms.textareaAutoResize(textarea));
+        textarea.addEventListener('keydown', e => Forms.textareaAutoResize(textarea));
   }
   
 }

--- a/src/forms.ts
+++ b/src/forms.ts
@@ -99,17 +99,7 @@ export class Forms {
 
       // File Input Path
       document.querySelectorAll('.file-field input[type="file"]').forEach((fileInput: HTMLInputElement) => {
-        fileInput.addEventListener('change', e => {
-          const fileField = fileInput.closest('.file-field');
-          const pathInput = <HTMLInputElement>fileField.querySelector('input.file-path');
-          const files = fileInput.files;
-          const filenames = [];
-          for (let i = 0; i < files.length; i++) {
-            filenames.push(files[i].name);
-          }
-          pathInput.value = filenames.join(', ');
-          pathInput.dispatchEvent(new Event('change'));
-        });
+          Forms.InitFileInputPath(fileInput);
       });
 
     });
@@ -123,6 +113,20 @@ export class Forms {
 
         textarea.addEventListener('keyup', e => Forms.textareaAutoResize(textarea));
         textarea.addEventListener('keydown', e => Forms.textareaAutoResize(textarea));
+  }
+
+  static InitFileInputPath(fileInput: HTMLInputElement){
+        fileInput.addEventListener('change', e => {
+          const fileField = fileInput.closest('.file-field');
+          const pathInput = <HTMLInputElement>fileField.querySelector('input.file-path');
+          const files = fileInput.files;
+          const filenames = [];
+          for (let i = 0; i < files.length; i++) {
+            filenames.push(files[i].name);
+          }
+          pathInput.value = filenames.join(', ');
+          pathInput.dispatchEvent(new Event('change'));
+        });
   }
   
 }


### PR DESCRIPTION
## Proposed changes
The current Forms.Init() function creates a DOMContentLoaded event which, when fired, will initialize the textareas and File Input Path present when the dom is loaded.
This mean that if we create a texarea programmatically, calling the Forms.Init() function will do nothing on the new created textarea.
We currently have no way to call the js code needed to initiate the textarea using the available functions.

That Pull request add the functions that will allow us to initialize the textarea and the File Input Path created programmatically.



## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
