### PR TITLE
Spacing helper classes

### DIFF
--- a/pug/contents/helpers_content.html
+++ b/pug/contents/helpers_content.html
@@ -122,7 +122,326 @@
 
       </div><!--  End Hiding Section  -->
 
-
+      <!-- Spacing Section -->
+      <div id="spacing" class="section scrollspy">
+        <h3 class="header">Spacing</h3>
+        <p>These classes help space elements with margin and padding helpers for all directions. This works by combining a margin/padding prefix, a direction infix and value suffix</p>
+        <h5>Prefix margin and padding modifiers</h5>
+        <table class="striped">
+          <thead>
+            <tr>
+              <th>Prefix</th>
+              <th>Modifies</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>m*</strong></code></td>
+              <td>Modifies the margin according to the infix and suffix values. If no infix is provided, it will be applied to all directions.</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>p*</strong></code></td>
+              <td>Modifies the padding according to the infix and suffix values. If no infix is provided, it will be applied to all directions.</td>
+            </tr>
+          </tbody>
+        </table>
+        <h5>Inffix direction modifiers</h5>
+        <table class="striped">
+          <thead>
+            <tr>
+              <th>Infix</th>
+              <th>Direction</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>*t</strong></code></td>
+              <td>Applies modifier to the top side of the element</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*r</strong></code></td>
+              <td>Applies modifier to the right side of the element</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*b</strong></code></td>
+              <td>Applies modifier to the bottom side of the element</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*l</strong></code></td>
+              <td>Applies modifier to the left side of the element</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*x</strong></code></td>
+              <td>Applies modifier to the left and right sides of the element</td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*y</strong></code></td>
+              <td>Applies modifier to the top and bottom sides of the element</td>
+            </tr>
+          </tbody>
+        </table>
+        <h5>Suffix values</h5>
+        <p>Any margin or padding modifier must be appended with one of 6 value suffixes</p>
+        <table class="striped">
+          <thead>
+            <tr>
+              <th>Suffix</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>*-0</strong></code></td>
+              <td><code class="language-markup"><strong>0</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-1</strong></code></td>
+              <td><code class="language-markup"><strong>0.25rem</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-2</strong></code></td>
+              <td><code class="language-markup"><strong>0.5rem</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-3</strong></code></td>
+              <td><code class="language-markup"><strong>0.75rem</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-4</strong></code></td>
+              <td><code class="language-markup"><strong>1rem</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-5</strong></code></td>
+              <td><code class="language-markup"><strong>1.5rem</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>*-6</strong></code></td>
+              <td><code class="language-markup"><strong>3rem</strong></code></td>
+            </tr>
+          </tbody>
+        </table>
+        <h5>Tables of all spacing helpers</h5>
+        <p>All margin helpers</p>
+        <table class="responsive-table">
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Prefix</th>
+              <th colspan="8">Classes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>margin</strong></code></td>
+              <td><code class="language-markup"><strong>m</strong></code></td>
+              <td><code class="language-markup"><strong>m-0</strong></code></td>
+              <td><code class="language-markup"><strong>m-1</strong></code></td>
+              <td><code class="language-markup"><strong>m-2</strong></code></td>
+              <td><code class="language-markup"><strong>m-3</strong></code></td>
+              <td><code class="language-markup"><strong>m-4</strong></code></td>
+              <td><code class="language-markup"><strong>m-5</strong></code></td>
+              <td><code class="language-markup"><strong>m-6</strong></code></td>
+              <td><code class="language-markup"><strong>m-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-top</strong></code></td>
+              <td><code class="language-markup"><strong>mt</strong></code></td>
+              <td><code class="language-markup"><strong>mt-0</strong></code></td>
+              <td><code class="language-markup"><strong>mt-1</strong></code></td>
+              <td><code class="language-markup"><strong>mt-2</strong></code></td>
+              <td><code class="language-markup"><strong>mt-3</strong></code></td>
+              <td><code class="language-markup"><strong>mt-4</strong></code></td>
+              <td><code class="language-markup"><strong>mt-5</strong></code></td>
+              <td><code class="language-markup"><strong>mt-6</strong></code></td>
+              <td><code class="language-markup"><strong>mt-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-right</strong></code></td>
+              <td><code class="language-markup"><strong>mr</strong></code></td>
+              <td><code class="language-markup"><strong>mr-0</strong></code></td>
+              <td><code class="language-markup"><strong>mr-1</strong></code></td>
+              <td><code class="language-markup"><strong>mr-2</strong></code></td>
+              <td><code class="language-markup"><strong>mr-3</strong></code></td>
+              <td><code class="language-markup"><strong>mr-4</strong></code></td>
+              <td><code class="language-markup"><strong>mr-5</strong></code></td>
+              <td><code class="language-markup"><strong>mr-6</strong></code></td>
+              <td><code class="language-markup"><strong>mr-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-bottom</strong></code></td>
+              <td><code class="language-markup"><strong>mb</strong></code></td>
+              <td><code class="language-markup"><strong>mb-0</strong></code></td>
+              <td><code class="language-markup"><strong>mb-1</strong></code></td>
+              <td><code class="language-markup"><strong>mb-2</strong></code></td>
+              <td><code class="language-markup"><strong>mb-3</strong></code></td>
+              <td><code class="language-markup"><strong>mb-4</strong></code></td>
+              <td><code class="language-markup"><strong>mb-5</strong></code></td>
+              <td><code class="language-markup"><strong>mb-6</strong></code></td>
+              <td><code class="language-markup"><strong>mb-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-left</strong></code></td>
+              <td><code class="language-markup"><strong>ml</strong></code></td>
+              <td><code class="language-markup"><strong>ml-0</strong></code></td>
+              <td><code class="language-markup"><strong>ml-1</strong></code></td>
+              <td><code class="language-markup"><strong>ml-2</strong></code></td>
+              <td><code class="language-markup"><strong>ml-3</strong></code></td>
+              <td><code class="language-markup"><strong>ml-4</strong></code></td>
+              <td><code class="language-markup"><strong>ml-5</strong></code></td>
+              <td><code class="language-markup"><strong>ml-6</strong></code></td>
+              <td><code class="language-markup"><strong>ml-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-top</strong></code> and <code class="language-markup"><strong>margin-bottom</strong></code></td>
+              <td><code class="language-markup"><strong>my</strong></code></td>
+              <td><code class="language-markup"><strong>my-0</strong></code></td>
+              <td><code class="language-markup"><strong>my-1</strong></code></td>
+              <td><code class="language-markup"><strong>my-2</strong></code></td>
+              <td><code class="language-markup"><strong>my-3</strong></code></td>
+              <td><code class="language-markup"><strong>my-4</strong></code></td>
+              <td><code class="language-markup"><strong>my-5</strong></code></td>
+              <td><code class="language-markup"><strong>my-6</strong></code></td>
+              <td><code class="language-markup"><strong>my-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>margin-left</strong></code> and <code class="language-markup"><strong>margin-right</strong></code></td>
+              <td><code class="language-markup"><strong>mx</strong></code></td>
+              <td><code class="language-markup"><strong>mx-0</strong></code></td>
+              <td><code class="language-markup"><strong>mx-1</strong></code></td>
+              <td><code class="language-markup"><strong>mx-2</strong></code></td>
+              <td><code class="language-markup"><strong>mx-3</strong></code></td>
+              <td><code class="language-markup"><strong>mx-4</strong></code></td>
+              <td><code class="language-markup"><strong>mx-5</strong></code></td>
+              <td><code class="language-markup"><strong>mx-6</strong></code></td>
+              <td><code class="language-markup"><strong>mx-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td colspan="2">Values</td>
+              <td>0</td>
+              <td>0.25rem</td>
+              <td>0.5rem</td>
+              <td>0.75rem</td>
+              <td>1rem</td>
+              <td>1.5rem</td>
+              <td>3rem</td>
+              <td>auto</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>All padding helpers</p>
+        <table class="responsive-table">
+          <thead>
+            <tr>
+              <th>Property</th>
+              <th>Prefix</th>
+              <th colspan="8">Classes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code class="language-markup"><strong>padding</strong></code></td>
+              <td><code class="language-markup"><strong>p</strong></code></td>
+              <td><code class="language-markup"><strong>p-0</strong></code></td>
+              <td><code class="language-markup"><strong>p-1</strong></code></td>
+              <td><code class="language-markup"><strong>p-2</strong></code></td>
+              <td><code class="language-markup"><strong>p-3</strong></code></td>
+              <td><code class="language-markup"><strong>p-4</strong></code></td>
+              <td><code class="language-markup"><strong>p-5</strong></code></td>
+              <td><code class="language-markup"><strong>p-6</strong></code></td>
+              <td><code class="language-markup"><strong>p-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-top</strong></code></td>
+              <td><code class="language-markup"><strong>pt</strong></code></td>
+              <td><code class="language-markup"><strong>pt-0</strong></code></td>
+              <td><code class="language-markup"><strong>pt-1</strong></code></td>
+              <td><code class="language-markup"><strong>pt-2</strong></code></td>
+              <td><code class="language-markup"><strong>pt-3</strong></code></td>
+              <td><code class="language-markup"><strong>pt-4</strong></code></td>
+              <td><code class="language-markup"><strong>pt-5</strong></code></td>
+              <td><code class="language-markup"><strong>pt-6</strong></code></td>
+              <td><code class="language-markup"><strong>pt-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-right</strong></code></td>
+              <td><code class="language-markup"><strong>pr</strong></code></td>
+              <td><code class="language-markup"><strong>pr-0</strong></code></td>
+              <td><code class="language-markup"><strong>pr-1</strong></code></td>
+              <td><code class="language-markup"><strong>pr-2</strong></code></td>
+              <td><code class="language-markup"><strong>pr-3</strong></code></td>
+              <td><code class="language-markup"><strong>pr-4</strong></code></td>
+              <td><code class="language-markup"><strong>pr-5</strong></code></td>
+              <td><code class="language-markup"><strong>pr-6</strong></code></td>
+              <td><code class="language-markup"><strong>pr-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-bottom</strong></code></td>
+              <td><code class="language-markup"><strong>pb</strong></code></td>
+              <td><code class="language-markup"><strong>pb-0</strong></code></td>
+              <td><code class="language-markup"><strong>pb-1</strong></code></td>
+              <td><code class="language-markup"><strong>pb-2</strong></code></td>
+              <td><code class="language-markup"><strong>pb-3</strong></code></td>
+              <td><code class="language-markup"><strong>pb-4</strong></code></td>
+              <td><code class="language-markup"><strong>pb-5</strong></code></td>
+              <td><code class="language-markup"><strong>pb-6</strong></code></td>
+              <td><code class="language-markup"><strong>pb-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-left</strong></code></td>
+              <td><code class="language-markup"><strong>pl</strong></code></td>
+              <td><code class="language-markup"><strong>pl-0</strong></code></td>
+              <td><code class="language-markup"><strong>pl-1</strong></code></td>
+              <td><code class="language-markup"><strong>pl-2</strong></code></td>
+              <td><code class="language-markup"><strong>pl-3</strong></code></td>
+              <td><code class="language-markup"><strong>pl-4</strong></code></td>
+              <td><code class="language-markup"><strong>pl-5</strong></code></td>
+              <td><code class="language-markup"><strong>pl-6</strong></code></td>
+              <td><code class="language-markup"><strong>pl-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-top</strong></code> and <code class="language-markup"><strong>padding-bottom</strong></code></td>
+              <td><code class="language-markup"><strong>py</strong></code></td>
+              <td><code class="language-markup"><strong>py-0</strong></code></td>
+              <td><code class="language-markup"><strong>py-1</strong></code></td>
+              <td><code class="language-markup"><strong>py-2</strong></code></td>
+              <td><code class="language-markup"><strong>py-3</strong></code></td>
+              <td><code class="language-markup"><strong>py-4</strong></code></td>
+              <td><code class="language-markup"><strong>py-5</strong></code></td>
+              <td><code class="language-markup"><strong>py-6</strong></code></td>
+              <td><code class="language-markup"><strong>py-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td><code class="language-markup"><strong>padding-left</strong></code> and <code class="language-markup"><strong>padding-right</strong></code></td>
+              <td><code class="language-markup"><strong>px</strong></code></td>
+              <td><code class="language-markup"><strong>px-0</strong></code></td>
+              <td><code class="language-markup"><strong>px-1</strong></code></td>
+              <td><code class="language-markup"><strong>px-2</strong></code></td>
+              <td><code class="language-markup"><strong>px-3</strong></code></td>
+              <td><code class="language-markup"><strong>px-4</strong></code></td>
+              <td><code class="language-markup"><strong>px-5</strong></code></td>
+              <td><code class="language-markup"><strong>px-6</strong></code></td>
+              <td><code class="language-markup"><strong>px-auto</strong></code></td>
+            </tr>
+            <tr>
+              <td colspan="2">Values</td>
+              <td>0</td>
+              <td>0.25rem</td>
+              <td>0.5rem</td>
+              <td>0.75rem</td>
+              <td>1rem</td>
+              <td>1.5rem</td>
+              <td>3rem</td>
+              <td>auto</td>
+            </tr>
+          </tbody>
+        </table>
+        <h5>Usage</h5>
+        <pre><code class="language-markup">
+          &lt;div class="p-2">
+            &lt;h5 class="mt-1">The div has a padding 0.5rem and the h5 has a margin-top of 0.25rem&lt;/h5>
+          &lt;/div>
+        </code></pre>
+      </div><!--  End Spacing Section  -->
 
       <!--  Formatting Section-->
       <div id="formatting" class="section scrollspy">
@@ -204,6 +523,7 @@
           <ul class="section table-of-contents">
             <li><a href="#valign">Alignment</a></li>
             <li><a href="#hiding">Hiding/Showing Content</a></li>
+            <li><a href="#spacing">Spacing Content</a></li>
             <li><a href="#formatting">Formatting</a></li>
             <li><a href="#browser-default">Browser Defaults</a></li>
           </ul>

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -666,3 +666,48 @@ td, th {
 .no-padding {
   padding: 0 !important;
 }
+
+/**************************
+  Utility Spacing Classes
+**************************/
+
+$spacing-shortcuts: ("margin": "m", "padding": "p") !default;
+$spacing-directions: ("top": "t", "right": "r", "bottom": "b", "left": "l") !default;
+$spacing-horizontal: "x" !default;
+$spacing-vertical: "y" !default;
+$spacing-values: ("0": 0, "1": 0.25rem, "2": 0.5rem, "3": 0.75rem, "4": 1rem, "5": 1.5rem, "6": 3rem, "auto": auto) !default; 
+
+@each $property, $shortcut in $spacing-shortcuts{
+  @each $name, $value in $spacing-values{
+    // All direction spacing
+
+    .#{$shortcut}-#{$name}{
+      #{$property}: $value !important;
+    }
+
+    // (t, b, r, l) spacing
+    @each $direction, $suffix in $spacing-directions{
+      .#{$shortcut}#{$suffix}-#{$name}{
+        #{$property}-#{$direction}: $value !important 
+      }
+    }
+
+    // x spacing
+    @if $spacing-horizontal != null{
+       .#{$shortcut}#{$spacing-horizontal}-#{$name}{
+         #{$property}-left: $value !important;
+         #{$property}-right: $value !important;
+       }
+    }
+
+    // y spacing
+    @if $spacing-vertical != null{
+      .#{$shortcut}#{$spacing-vertical}-#{$name}{
+        #{$property}-top: $value !important;
+        #{$property}-bottom: $value !important;
+      }
+        
+    }
+      
+  }
+} 


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
#408 
New spacing helper SCSS classes for adding margin and padding to any element. The classes have the same utilization as the tailwind classes counterpart: with a combination of prefix, infix and suffix to create all the cardinal spacing combinations. The documentation was updated accordingly with tables explaining all the prefixes, infixes, suffixes and all the posible combinations in the helpers html page.
## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
