### PR TITLE
fix(datepicker): Date picker didnot change calendar when selecting month or year from dropdown

### DIFF
--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -134,7 +134,7 @@ export interface DatepickerOptions extends BaseOptions {
    * @default null
    */
   onDraw: (() => void) | null;
-  
+
   /** Field used for internal calculations DO NOT CHANGE IT */
   minYear?: any;
   /** Field used for internal calculations DO NOT CHANGE IT */
@@ -261,7 +261,7 @@ export class Datepicker extends Component<DatepickerOptions> {
   constructor(el: HTMLInputElement, options: Partial<DatepickerOptions>) {
     super(el, options, Datepicker);
     (this.el as any).M_Datepicker = this;
-    
+
     this.options = {
       ...Datepicker.defaults,
       ...options
@@ -847,8 +847,8 @@ export class Datepicker extends Component<DatepickerOptions> {
     });
 
     // Add change handlers for select
-    yearSelect.addEventListener('change', () => this._handleYearChange);
-    monthSelect.addEventListener('change', () => this._handleMonthChange);
+    yearSelect.addEventListener('change', this._handleYearChange);
+    monthSelect.addEventListener('change', this._handleMonthChange);
 
     if (typeof this.options.onDraw === 'function') {
       this.options.onDraw.call(this);


### PR DESCRIPTION
## Proposed changes
When you select a different month or year in the date picker dropdown, it does not actually change the calendar to that month or year. This PR fixes that bug. Issue #412 

## Screenshots (if appropriate) or codepen:
Original: https://jsfiddle.net/SeCrEt_BoY/m50y8Lq3/8/
After Fix: https://jsfiddle.net/abhigyanghosh30/odushvaz/32/

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
