### PR TITLE
feat(toast): property to specify an element as toast content instead …

### DIFF
--- a/src/toasts.ts
+++ b/src/toasts.ts
@@ -9,6 +9,11 @@ export interface ToastOptions extends BaseOptions {
    */
   text: string;
   /**
+   * Element Id for the tooltip.
+   * @default ""
+   */
+  toastId?: string;
+  /**
    * Length in ms the Toast stays before dismissal.
    * @default 4000
    */
@@ -53,7 +58,7 @@ let _defaults: ToastOptions = {
 
 export class Toast {
   /** The toast element. */
-  el: HTMLDivElement;
+  el: HTMLElement;
   /**
    * The remaining amount of time in ms that the toast
    * will stay before dismissal.
@@ -199,7 +204,10 @@ export class Toast {
   }
 
   _createToast() {
-    const toast = document.createElement('div');
+    const toast = this.options.toastId 
+      ? document.getElementById(this.options.toastId)
+      : document.createElement('div');
+    //const toast = document.createElement('div');
     toast.classList.add('toast');
     toast.setAttribute('role', 'alert');
     toast.setAttribute('aria-live', 'assertive');
@@ -211,7 +219,8 @@ export class Toast {
     }
 
     // Set text content
-    toast.innerText = this.message;
+    if (this.message)
+      toast.innerText = this.message;
 
     // Append toast
     Toast._container.appendChild(toast);
@@ -220,6 +229,7 @@ export class Toast {
 
   _animateIn() {
     // Animate toast in
+    this.el.style.display = ""
     anim({
       targets: this.el,
       top: 0,
@@ -273,10 +283,12 @@ export class Toast {
           this.options.completeCallback();
         }
         // Remove toast from DOM
-        this.el.remove();
-        Toast._toasts.splice(Toast._toasts.indexOf(this), 1);
-        if (Toast._toasts.length === 0) {
-          Toast._removeContainer();
+        if (!this.options.toastId) {
+          this.el.remove();
+          Toast._toasts.splice(Toast._toasts.indexOf(this), 1);
+          if (Toast._toasts.length === 0) {
+            Toast._removeContainer();
+          }  
         }
       }
     });


### PR DESCRIPTION
## Proposed changes
Alternative solution to "[Bug]: Toast html/unsafeHtml not work #394 ". This will allow to specify some element as toast content. A new property `toastId` will allow specify an element as tooltip content instead of text.

## Screenshots (if appropriate) or codepen:


will appear as (this also shows part of corresponding update in docs)

![imagen](https://github.com/materializecss/materialize/assets/80809/f8892b10-a1a4-4e79-9c18-ca684ffc3f70)



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [ x I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, ~and updated it accordingly~.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
