### PR TITLE
chore: do not include module section in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "homepage": "https://materializeweb.com",
   "version": "2.0.3",
   "main": "dist/js/materialize.js",
-  "module": "src/index.ts",
   "style": "dist/css/materialize.css",
   "sass": "sass/materialize.scss",
   "typings": "dist/src/index.d.ts",


### PR DESCRIPTION
This was causing issues as 'failed to resolve entry for package "@materializecss/materialize #455'

This entry is not needed anymore in materialize-docs when the pull request  https://github.com/materializecss/materialize-docs/pull/5 will be merged.

## Proposed changes
remove "module": "src/index.ts" entry in package.json

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
