### PR TITLE
fixes #456 dropdown open/close bug

### DIFF
--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -197,22 +197,24 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
   }
 
   _setupTemporaryEventHandlers() {
-    // Use capture phase event handler to prevent click
-    document.body.addEventListener('click', this._handleDocumentClick, true);
+    document.body.addEventListener('click', this._handleDocumentClick);
     document.body.addEventListener('touchmove', this._handleDocumentTouchmove);
     this.dropdownEl.addEventListener('keydown', this._handleDropdownKeydown);
   }
 
   _removeTemporaryEventHandlers() {
-    // Use capture phase event handler to prevent click
-    document.body.removeEventListener('click', this._handleDocumentClick, true);
+    document.body.removeEventListener('click', this._handleDocumentClick);
     document.body.removeEventListener('touchmove', this._handleDocumentTouchmove);
     this.dropdownEl.removeEventListener('keydown', this._handleDropdownKeydown);
   }
 
   _handleClick = (e: MouseEvent) => {
     e.preventDefault();
-    this.open();
+    if (this.isOpen) {
+        this.close();
+    } else {
+        this.open();
+    }
   }
 
   _handleMouseEnter = () => {
@@ -245,17 +247,18 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
       !this.isTouchMoving
     ) {
       // isTouchMoving to check if scrolling on mobile.
-      //setTimeout(() => {
       this.close();
-      //}, 0);
     }
     else if (
-      target.closest('.dropdown-trigger') ||
       !target.closest('.dropdown-content')
     ) {
-      //setTimeout(() => {
-      this.close();
-      //}, 0);
+      // Do this one frame later so that if the element clicked also triggers _handleClick
+      // For example, if a label for a select was clicked, that we don't close/open the dropdown
+      setTimeout(() => {
+        if (this.isOpen) {
+          this.close();
+        }
+      }, 0);
     }
     this.isTouchMoving = false;
   }
@@ -592,7 +595,9 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
     this.dropdownEl.style.display = 'block';
     this._placeDropdown();
     this._animateIn();
-    this._setupTemporaryEventHandlers();
+    // Do this one frame later so that we don't bind an event handler that's immediately
+    // called when the event bubbles up to the document and closes the dropdown
+    setTimeout(() => this._setupTemporaryEventHandlers(), 0);
   }
 
   /**


### PR DESCRIPTION
fix bug causing menu to toggle #456 

Either this PR or PR #452 should be merged; probably not both

## Proposed changes
- Fix a bug where multiple clicks on a dropdown trigger would cause the dropdown to open/close on the 2nd+ clicks

- Behaviour would also occur for the select component whichleveragesthe dropdown component

- Special consideration was given to the scenario where a select component has a label; where upon clicking the label the dropdown's _handleClick would be called, but the click event would not contain the dropdown-trigger (which is the select). Which would previously call both the _handleClick and _handleDocumentClick functions causing the same open/close behaviour


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
