### PR TITLE
fix: class="active" non-accordion collapsible not opening by default

### DIFF
--- a/src/collapsible.ts
+++ b/src/collapsible.ts
@@ -68,12 +68,12 @@ export class Collapsible extends Component<CollapsibleOptions> {
 
     // Open active
     const activeBodies: HTMLElement[] = Array.from(this.el.querySelectorAll('li.active > .collapsible-body'));
-    if (this.options.accordion)
+    if (this.options.accordion) {
       if (activeBodies.length > 0) {
         // Accordion => open first active only
         this._setExpanded(activeBodies[0]);
       }
-    else {
+    } else {
       // Expandables => all active
       activeBodies.forEach(el => this._setExpanded(el));
     }


### PR DESCRIPTION
fix bug causing collapsible to not auto open

 - Can't exactly explain why it was doing this, but in my development today I noticed that some of my non-accordion collapsibles weren't having their li's with class="active" set on them opening by default. Played around with the code a bit and found that putting these brackets back seemed to resolve it, so here we are

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
