### PR TITLE
fix: #446 Textarea not autoresize bug

### DIFF
--- a/src/forms.ts
+++ b/src/forms.ts
@@ -94,7 +94,7 @@ export class Forms {
       });
 
       document.querySelectorAll('.materialize-textarea').forEach((textArea: HTMLTextAreaElement) => {
-          Forms.textareaAutoResize(textArea);
+          Forms.InitTextarea(textArea);
       });
 
       // File Input Path

--- a/tests/spec/forms/formsSpec.js
+++ b/tests/spec/forms/formsSpec.js
@@ -1,3 +1,5 @@
+const MULTILINE_TEXT = 'This is line 1.\nThis is line 2.\nThis is line 3.\nThis is line 4.\nThis is line 5.\nAnd this is line 6.';
+
 describe('Forms:', function () {
   beforeEach(async function () {
     await XloadFixtures(['forms/formsFixture.html']);
@@ -45,6 +47,26 @@ describe('Forms:', function () {
       `.trim();
       M.Forms.textareaAutoResize(el);
       expect(el.clientHeight).toBeGreaterThan(pHeight);
+    });
+
+    it('Programmatically initialized textarea resize', () => {
+      const element = document.querySelector('#textarea');
+      M.Forms.InitTextarea(element);
+      const textareaHeight = element.clientHeight;
+      element.value = MULTILINE_TEXT;
+      keydown(element, 13);
+      expect(element.clientHeight).toBeGreaterThan(textareaHeight);
+    });
+
+    it('Automatically initialized textarea resize', () => {
+      const event = new Event('DOMContentLoaded');
+      document.dispatchEvent(event);
+
+      const element = document.querySelector('#textarea');
+      const textareaHeight = element.clientHeight;
+      element.value = MULTILINE_TEXT;
+      keydown(element, 13);
+      expect(element.clientHeight).toBeGreaterThan(textareaHeight);
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/materializecss/materialize/issues/446
resize textarea should work without explicit initialization

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
