### PR TITLE
test(autocomplete): cover autocomplete component

### DIFF
--- a/tests/spec/autocomplete/autocompleteSpec.js
+++ b/tests/spec/autocomplete/autocompleteSpec.js
@@ -128,7 +128,93 @@ describe('Autocomplete Plugin', function () {
         });
       });
     });
+
+    it('destroy method should properly dispose autocomplete component', function () {
+      const normal = document.querySelector('#normal-autocomplete');
+      const limited = document.querySelector('#limited-autocomplete');
+
+      expect(normal.parentNode.querySelector('.autocomplete-content')).not.toBeNull();
+      expect(limited.parentNode.querySelector('.autocomplete-content')).not.toBeNull();
+
+      const normalInstance = M.Autocomplete.getInstance(normal);
+      const limitedInstance = M.Autocomplete.getInstance(limited);
+      normalInstance.destroy();
+      limitedInstance.destroy();
+
+      expect(normal.parentNode.querySelector('.autocomplete-content')).toBeNull();
+      expect(limited.parentNode.querySelector('.autocomplete-content')).toBeNull();
+    });
+
+    it('selectOption method should chose only from showed dropdown', function (done) {
+      const normal = document.querySelector('#normal-autocomplete');
+      const autocompleteInstance = resetAutocomplete(normal, [
+        { id: 'Value Q1' },
+        { id: 'Value Q' },
+        { id: 'Value R' }]);
+      const autocompleteEl = normal.parentNode.querySelector('.autocomplete-content');
+
+      focus(normal);
+      normal.value = 'Q';
+      keyup(normal, 81);
+
+      setTimeout(function () {
+        expect(autocompleteEl.children.length).toBe(2);
+        const dropdownAutocompleteIds = Array
+          .from(autocompleteEl.querySelectorAll('li'))
+          .map(liElement => liElement.getAttribute('data-id'));
+        expect(dropdownAutocompleteIds).toEqual(['Value Q1', 'Value Q']);
+
+        autocompleteInstance.selectOption('Value R');
+        expect(normal.value)
+          .withContext('Only options from dropdown can be selected through selectOption')
+          .toBe('Q');
+        autocompleteInstance.selectOption('Value Q');
+        expect(normal.value)
+          .withContext('Only options from dropdown can be selected through selectOption')
+          .toBe('Value Q');
+        done();
+      }, 200);
+    });
+
+    it('setValues method should chose from any init data entry', function (done) {
+      const normal = document.querySelector('#normal-autocomplete');
+      const autocompleteInstance = resetAutocomplete(normal, [
+        { id: 'Value Q1' },
+        { id: 'Value Q' },
+        { id: 'Value R' }]);
+      const autocompleteEl = normal.parentNode.querySelector('.autocomplete-content');
+
+      focus(normal);
+      normal.value = 'Q';
+      keyup(normal, 81);
+
+      setTimeout(function () {
+        expect(autocompleteEl.children.length).toBe(2);
+        const dropdownAutocompleteIds = Array
+          .from(autocompleteEl.querySelectorAll('li'))
+          .map(liElement => liElement.getAttribute('data-id'));
+        expect(dropdownAutocompleteIds).toEqual(['Value Q1', 'Value Q']);
+
+        autocompleteInstance.setValues([{ id: 'Value R' }]);
+        expect(normal.value)
+          .withContext('Any option from init data can be selected through setValues')
+          .toBe('Value R');
+        autocompleteInstance.setValues([{ id: 'Value Q' }]);
+        expect(normal.value)
+          .withContext('Any option from init data can be selected through setValues')
+          .toBe('Value Q');
+        done();
+      }, 200);
+    });
   });
+
+  function resetAutocomplete(autocompleteElement, data) {
+    M.Autocomplete.getInstance(autocompleteElement).destroy();
+    return M.Autocomplete.init(autocompleteElement, {
+      data: data,
+      minLength: 0
+    });
+  }
 
   function openDropdownAndSelectFirstOption(autocomplete, onFinish) {
     click(autocomplete);


### PR DESCRIPTION
related to https://github.com/materializecss/materialize/issues/479
add tests autocomplete component, for destroy,
selectOption and setValues methods

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Screenshots (if appropriate) or codepen:
<!-- Add supplemental screenshots or code examples. Look for a codepen template in our **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/master/CONTRIBUTING.md)**. -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
