### PR TITLE
 fix(tapTarget): restore Feature Discovery animation and fix #488

### DIFF
--- a/sass/components/_tapTarget.scss
+++ b/sass/components/_tapTarget.scss
@@ -36,8 +36,8 @@
   position: absolute;
   font-size: 1rem;
   border-radius: 50%;
-  background-color: var(--md-sys-color-surface);//var(--md-sys-color-secondary);
-  color: var(--md-sys-color-on-secondary);
+  background-color: var(--md-sys-color-primary-container);
+  color: var(--md-sys-color-primary);
   box-shadow: 0 20px 20px 0 rgba(0, 0, 0, 0.14), 0 10px 50px 0 rgba(0, 0, 0, 0.12), 0 30px 10px -20px rgba(0, 0, 0, 0.2);
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Proposed changes
The Feature Discovery animation no longer works in 2.1.0 because the  background of the component is white.
As solution, we change the component's background color and text color to use the same color as the btn-floating at the bottom right of the tap component.

## Screenshots (if appropriate) or codepen:

before:
![image](https://github.com/user-attachments/assets/18554935-2936-4410-aea4-63538867e168)

After:
![image](https://github.com/user-attachments/assets/ad8eb5bc-e9e8-484e-971f-54ed93d9ba2e)


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
