### PR TITLE
fix(Dropdown): accessibility - implemented aria-expanded #229

### DIFF
--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -125,6 +125,7 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
     this.isTouchMoving = false;
     this.focusedIndex = -1;
     this.filterQuery = [];
+    this.el.ariaExpanded = 'false'
 
     // Move dropdown-content after dropdown-trigger
     this._moveDropdown();
@@ -610,6 +611,7 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
     // Do this one frame later so that we don't bind an event handler that's immediately
     // called when the event bubbles up to the document and closes the dropdown
     setTimeout(() => this._setupTemporaryEventHandlers(), 0);
+    this.el.ariaExpanded = 'true'
   }
 
   /**
@@ -628,6 +630,7 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
     if (this.options.autoFocus) {
       this.el.focus();
     }
+    this.el.ariaExpanded = 'false'
   }
 
   /**


### PR DESCRIPTION
## Proposed changes
Dropdown component missing aria-expanded state, this causes a reduction in exposure to the web accessibility API, see #229

## Types of changes
Implemented aria-expanded to initiator, open and close methods

- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
