### PR TITLE
(fix) Dropdown menu visibility #515

### DIFF
--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -212,6 +212,7 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
 
   _handleClick = (e: MouseEvent) => {
     e.preventDefault();
+    this._moveDropdown((<HTMLElement>e.target).closest('li'));
     if (this.isOpen) {
         this.close();
     } else {
@@ -219,7 +220,8 @@ export class Dropdown extends Component<DropdownOptions> implements Openable {
     }
   }
 
-  _handleMouseEnter = () => {
+  _handleMouseEnter = (e) => {
+    this._moveDropdown((<HTMLElement>e.target).closest('li'));
     this.open();
   }
 


### PR DESCRIPTION
## Proposed changes

### Current behaviour
Since the dropdown content is currently being appended to the container element of the latest triggering element, the dropdown content might get appended to a container that is currently in invisible state, this happens in the context where the dropdown component has multiple trigger elements, where triggering elements containers might become invisible because of a toggling visibility state (tabbable content, expandables, media queries, ...)

### Implemented changes
Updated the dropdown content to be attached to the current clicked/hovered triggering element

## Screenshots (if appropriate) or codepen:
[Example of bug using a dropdown in nav/sidenav
](https://codepen.io/Geert-Selderslaghs/pen/JjgWXeW)
[Example of bug using a dropdown with multiple triggers in tabs context
](https://codepen.io/Geert-Selderslaghs/pen/gOVeLJq)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
