### PR TITLE
Timepicker accessibility #476

### DIFF
--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -34,10 +34,10 @@
   user-select: none;
   padding: 1rem 1rem 1.5rem 1rem;
 
-  input[type=number] {
+  input[type=text]{
     height: 4rem;
     color: var(--md-sys-color-secondary);
-    border-bottom: 0;
+    border-bottom: 0px;
     font-size: 4rem;
     direction: ltr;
   }
@@ -49,18 +49,18 @@
   cursor: pointer;
 }
 
-input[type=number].timepicker-input-hours {
+input[type=text].timepicker-input-hours {
   text-align: right;
   width: 28%;
   margin-right: 3px;
 }
 
-input[type=number].timepicker-input-minutes {
+input[type=text].timepicker-input-minutes {
   width: 33%;
   margin-left: 3px;
 }
 
-input[type=number].text-primary {
+input[type=text].text-primary {
   color: var(--md-sys-color-on-background);
 }
 
@@ -217,12 +217,8 @@ input[type=number].text-primary {
     margin-top: 1.2rem;
   }
 
-  input[type=number].timepicker-input-hours {
-    min-width: 6rem;
-  }
-
-  input[type=number].timepicker-input-minutes {
-    min-width: 6.5rem;
+  input[type=text].timepicker-input-minutes {
+    min-width: 5.3rem;
   }
 
   .timepicker-modal .am-btn,

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -56,7 +56,7 @@ input[type=text].timepicker-input-hours {
 }
 
 input[type=text].timepicker-input-minutes {
-  width: 36%;
+  width: 33%;
   margin-left: 3px;
 }
 
@@ -217,12 +217,8 @@ input[type=text].text-primary {
     margin-top: 1.2rem;
   }
 
-  .timepicker-digital-display {
-    width: inherit;
-  }
-
   input[type=text].timepicker-input-minutes {
-    width: 36%;
+    min-width: 5.3rem;
   }
 
   .timepicker-modal .am-btn,

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -69,18 +69,17 @@ input[type=text].text-primary {
   position: absolute;
   top: 1.2rem;
   right: 1rem;
-  font-weight: 400;
   bottom: auto;
+  font-weight: 400;
 }
 
-.timepicker-modal .am-btn {
-  .timepicker-modal .pm-btn {
-    width: 3.6rem;
-    height: 2rem;
-    line-height: 2rem;
-    vertical-align: middle;
-    text-align: center;
-  }
+.timepicker-modal .am-btn,
+.timepicker-modal .pm-btn {
+  width: 3.6rem;
+  height: 2rem;
+  line-height: 2rem;
+  vertical-align: middle;
+  text-align: center;
 }
 
 /* Analog Clock Display */
@@ -96,9 +95,8 @@ input[type=text].text-primary {
   height: 270px;
   overflow: visible;
   position: relative;
-  margin: auto;
-  margin-top: 25px;
-  margin-bottom: 5px;
+  margin: 30px 14px 14px;
+  padding: 10px;
   user-select: none;
 }
 
@@ -206,13 +204,33 @@ input[type=text].text-primary {
 
   .timepicker-text-container {
     top: 32%;
+    padding: 0;
+    text-align: center;
   }
 
   .timepicker-display-am-pm {
     position: relative;
+    top: auto;
     right: auto;
     bottom: auto;
     text-align: center;
     margin-top: 1.2rem;
+  }
+
+  .timepicker-digital-display {
+    width: inherit;
+  }
+
+  input[type=text].timepicker-input-minutes {
+    width: 36%;
+  }
+
+  .timepicker-modal .am-btn,
+  .timepicker-modal .pm-btn {
+    width: auto;
+    height: auto;
+    line-height: inherit;
+    vertical-align: top;
+    text-align: inherit;
   }
 }

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -34,10 +34,10 @@
   user-select: none;
   padding: 1rem 1rem 1.5rem 1rem;
 
-  input[type=text]{
+  input[type=number] {
     height: 4rem;
     color: var(--md-sys-color-secondary);
-    border-bottom: 0px;
+    border-bottom: 0;
     font-size: 4rem;
     direction: ltr;
   }
@@ -49,18 +49,18 @@
   cursor: pointer;
 }
 
-input[type=text].timepicker-input-hours {
+input[type=number].timepicker-input-hours {
   text-align: right;
   width: 28%;
   margin-right: 3px;
 }
 
-input[type=text].timepicker-input-minutes {
+input[type=number].timepicker-input-minutes {
   width: 33%;
   margin-left: 3px;
 }
 
-input[type=text].text-primary {
+input[type=number].text-primary {
   color: var(--md-sys-color-on-background);
 }
 
@@ -217,8 +217,12 @@ input[type=text].text-primary {
     margin-top: 1.2rem;
   }
 
-  input[type=text].timepicker-input-minutes {
-    min-width: 5.3rem;
+  input[type=number].timepicker-input-hours {
+    min-width: 6rem;
+  }
+
+  input[type=number].timepicker-input-minutes {
+    min-width: 6.5rem;
   }
 
   .timepicker-modal .am-btn,

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -35,7 +35,7 @@
 
   input[type=text]{
     height: 4rem;
-    color: rgba(255, 255, 255, 0.6);
+    color: var(--md-sys-color-secondary);
     border-bottom: 0px;
     font-size: 4rem;
     direction: ltr;
@@ -60,7 +60,7 @@ input[type=text].timepicker-input-minutes {
 }
 
 input[type=text].text-primary {
-  color: rgba(255, 255, 255, 1);
+  color: var(--md-sys-color-on-background);
 }
 
 .timepicker-display-am-pm {

--- a/sass/components/_timepicker.scss
+++ b/sass/components/_timepicker.scss
@@ -17,7 +17,7 @@
 
 /* Clock Digital Display */
 .timepicker-digital-display {
-  width: 200px;
+  width: auto;
   flex: 1 auto;
   background-color: var(--md-sys-color-primary);;
   padding: 10px;
@@ -27,11 +27,12 @@
 .timepicker-text-container {
   font-size: 4rem;
   font-weight: bold;
-  text-align: center;
+  text-align: left;
   color: var(--font-on-primary-color-medium);
   font-weight: 400;
   position: relative;
   user-select: none;
+  padding: 1rem 1rem 1.5rem 1rem;
 
   input[type=text]{
     height: 4rem;
@@ -55,7 +56,7 @@ input[type=text].timepicker-input-hours {
 }
 
 input[type=text].timepicker-input-minutes {
-  width: 33%;
+  width: 36%;
   margin-left: 3px;
 }
 
@@ -66,11 +67,21 @@ input[type=text].text-primary {
 .timepicker-display-am-pm {
   font-size: 1.3rem;
   position: absolute;
+  top: 1.2rem;
   right: 1rem;
-  bottom: 1rem;
   font-weight: 400;
+  bottom: auto;
 }
 
+.timepicker-modal .am-btn {
+  .timepicker-modal .pm-btn {
+    width: 3.6rem;
+    height: 2rem;
+    line-height: 2rem;
+    vertical-align: middle;
+    text-align: center;
+  }
+}
 
 /* Analog Clock Display */
 .timepicker-analog-display {

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -568,7 +568,7 @@ export class Timepicker extends Component<TimepickerOptions> {
     }
     this.hours = +value[0] || 0;
     this.minutes = +value[1] || 0;
-    this.inputHours.value = this.hours;
+    this.inputHours.value = Timepicker._addLeadingZero(this.hours);
     this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes);
 
     this._updateAmPmView();
@@ -734,7 +734,7 @@ export class Timepicker extends Component<TimepickerOptions> {
 
     this[this.currentView] = value;
     if (isHours) {
-      this.inputHours.value = value.toString();
+      this.inputHours.value = Timepicker._addLeadingZero(value);
     }
     else {
       this.inputMinutes.value = Timepicker._addLeadingZero(value);

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -664,7 +664,11 @@ export class Timepicker extends Component<TimepickerOptions> {
     const unit = Math.PI / (isHours ? 6 : 30);
     const radian = value * unit;
     let radius;
-    radius = isHours && value > 0 && value < 13 ? this.options.innerRadius : this.options.outerRadius;
+    if (this.options.twelveHour) {
+      radius = this.options.outerRadius;
+    } else {
+      radius = isHours && value > 0 && value < 13 ? this.options.innerRadius : this.options.outerRadius;
+    }
     this.setClockAttributes(radian, radius);
   }
 

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -361,9 +361,23 @@ export class Timepicker extends Component<TimepickerOptions> {
 
   _setupModal() {
     this.modal = Modal.init(this.modalEl, {
-      onOpenStart: this.options.onOpenStart,
+      onOpenStart: () => {
+        if (typeof this.options.onOpenStart === 'function') {
+          this.options.onOpenStart.call(this);
+        }
+        this.modalEl.querySelectorAll('.btn').forEach((e: HTMLButtonElement) => {
+          if (e.style.visibility !== 'hidden') e.setAttribute('tabindex', '0');
+        });
+      },
       onOpenEnd: this.options.onOpenEnd,
-      onCloseStart: this.options.onCloseStart,
+      onCloseStart: () => {
+        if (typeof this.options.onCloseStart === 'function') {
+          this.options.onCloseStart.call(this);
+        }
+        this.modalEl.querySelectorAll('.btn').forEach((e: HTMLButtonElement) => {
+          e.setAttribute('tabindex', '-1');
+        });
+      },
       onCloseEnd: () => {
         if (typeof this.options.onCloseEnd === 'function') {
           this.options.onCloseEnd.call(this);
@@ -394,10 +408,10 @@ export class Timepicker extends Component<TimepickerOptions> {
 
   private _createButton(text: string, visibility: string): HTMLButtonElement {
     const button = document.createElement('button');
-    button.classList.add('btn-flat', 'waves-effect');
+    button.classList.add('btn', 'btn-flat', 'waves-effect', 'text');
     button.style.visibility = visibility;
     button.type = 'button';
-    button.tabIndex = this.options.twelveHour ? 3 : 1;
+    button.tabIndex = -1;
     button.innerText = text;
     return button;
   }

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -819,9 +819,9 @@ export class Timepicker extends Component<TimepickerOptions> {
           <div class="timepicker-digital-display">
             <div class="timepicker-text-container">
               <div class="timepicker-display-column">
-                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary"/>
+                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary" min="1" max="12"/>
                 :
-                <input type="number" maxlength="2" class="timepicker-input-minutes"/>
+                <input type="number" maxlength="2" class="timepicker-input-minutes" min="0" max="59"/>
               </div>
               <div class="timepicker-display-column timepicker-display-am-pm">
                 <div class="timepicker-span-am-pm"></div>

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -253,7 +253,7 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.el.addEventListener('keydown', this._handleInputKeydown);
     this.plate.addEventListener('mousedown', this._handleClockClickStart);
     this.plate.addEventListener('touchstart', this._handleClockClickStart);
-    this.digitalClock.addEventListener('change', this._inputFromTextField);
+    this.digitalClock.addEventListener('keyup', this._inputFromTextField);
     this.inputHours.addEventListener('focus', () => this.showView('hours'));
     this.inputMinutes.addEventListener('focus', () => this.showView('minutes'));
     this.inputMinutes.addEventListener('focusout', () => this.formatMinutes());
@@ -568,7 +568,7 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.hours = +value[0] || 0;
     this.minutes = +value[1] || 0;
     this.inputHours.value = this.hours;
-    this.inputMinutes.value = this.minutes;
+    this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes);
 
     this._updateAmPmView();
   }
@@ -819,9 +819,9 @@ export class Timepicker extends Component<TimepickerOptions> {
           <div class="timepicker-digital-display">
             <div class="timepicker-text-container">
               <div class="timepicker-display-column">
-                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary" min="1" max="12"/>
+                <input type="text" maxlength="2" autofocus class="timepicker-input-hours text-primary" />
                 :
-                <input type="number" maxlength="2" class="timepicker-input-minutes" min="0" max="59"/>
+                <input type="text" maxlength="2" class="timepicker-input-minutes" />
               </div>
               <div class="timepicker-display-column timepicker-display-am-pm">
                 <div class="timepicker-span-am-pm"></div>

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -253,9 +253,10 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.el.addEventListener('keydown', this._handleInputKeydown);
     this.plate.addEventListener('mousedown', this._handleClockClickStart);
     this.plate.addEventListener('touchstart', this._handleClockClickStart);
-    this.digitalClock.addEventListener('keyup', this._inputFromTextField);
-    this.inputHours.addEventListener('click', () => this.showView('hours'));
-    this.inputMinutes.addEventListener('click', () => this.showView('minutes'));
+    this.digitalClock.addEventListener('change', this._inputFromTextField);
+    this.inputHours.addEventListener('focus', () => this.showView('hours'));
+    this.inputMinutes.addEventListener('focus', () => this.showView('minutes'));
+    this.inputMinutes.addEventListener('focusout', () => this.formatMinutes());
   }
 
   _removeEventHandlers() {
@@ -567,7 +568,7 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.hours = +value[0] || 0;
     this.minutes = +value[1] || 0;
     this.inputHours.value = this.hours;
-    this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes);
+    this.inputMinutes.value = this.minutes;
 
     this._updateAmPmView();
   }
@@ -639,9 +640,7 @@ export class Timepicker extends Component<TimepickerOptions> {
       const value = parseInt(this.inputHours.value);
       if (value > 0 && value < 13) {
         this.drawClockFromTimeInput(value, isHours);
-        this.showView('minutes', this.options.duration / 2);
         this.hours = value;
-        this.inputMinutes.focus();
       }
       else {
         const hour = new Date().getHours();
@@ -651,10 +650,9 @@ export class Timepicker extends Component<TimepickerOptions> {
     else {
       const value = parseInt(this.inputMinutes.value);
       if (value >= 0 && value < 60) {
-        this.inputMinutes.value = Timepicker._addLeadingZero(value);
+        this.inputMinutes.value = String(value);
         this.drawClockFromTimeInput(value, isHours);
         this.minutes = value;
-        (<HTMLElement>this.modalEl.querySelector('.confirmation-btns :nth-child(2)')).focus();
       }
       else {
         const minutes = new Date().getMinutes();
@@ -759,6 +757,10 @@ export class Timepicker extends Component<TimepickerOptions> {
     this.bg.setAttribute('cy', cy2.toString());
   }
 
+  formatMinutes() {
+    this.inputMinutes.value = Timepicker._addLeadingZero(Number(this.inputMinutes.value));
+  }
+
   /**
    * Open timepicker.
    */
@@ -809,9 +811,9 @@ export class Timepicker extends Component<TimepickerOptions> {
           <div class="timepicker-digital-display">
             <div class="timepicker-text-container">
               <div class="timepicker-display-column">
-                <input type="text" maxlength="2" autofocus class="timepicker-input-hours text-primary" />
+                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary" min="1" max="12"/>
                 :
-                <input type="text" maxlength="2" class="timepicker-input-minutes" />
+                <input type="number" maxlength="2" class="timepicker-input-minutes" min="0" max="59"/>
               </div>
               <div class="timepicker-display-column timepicker-display-am-pm">
                 <div class="timepicker-span-am-pm"></div>

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -366,7 +366,7 @@ export class Timepicker extends Component<TimepickerOptions> {
           this.options.onOpenStart.call(this);
         }
         this.modalEl.querySelectorAll('.btn').forEach((e: HTMLButtonElement) => {
-          if (e.style.visibility !== 'hidden') e.setAttribute('tabindex', '0');
+          if (e.style.visibility !== 'hidden') e.tabIndex = 0;
         });
       },
       onOpenEnd: this.options.onOpenEnd,
@@ -375,7 +375,7 @@ export class Timepicker extends Component<TimepickerOptions> {
           this.options.onCloseStart.call(this);
         }
         this.modalEl.querySelectorAll('.btn').forEach((e: HTMLButtonElement) => {
-          e.setAttribute('tabindex', '-1');
+          e.tabIndex = -1;
         });
       },
       onCloseEnd: () => {

--- a/src/timepicker.ts
+++ b/src/timepicker.ts
@@ -639,25 +639,33 @@ export class Timepicker extends Component<TimepickerOptions> {
     if (isHours) {
       const value = parseInt(this.inputHours.value);
       if (value > 0 && value < 13) {
-        this.drawClockFromTimeInput(value, isHours);
         this.hours = value;
       }
-      else {
-        const hour = new Date().getHours();
-        this.inputHours.value = (hour % 12).toString();
+      else if(value == 0) {
+        this.hours = 12;
+        this.inputHours.value = this.hours.toString();
       }
+      else {
+        this.hours = 1;
+        this.inputHours.value = this.hours.toString();
+      }
+      this.drawClockFromTimeInput(this.hours, isHours);
     }
     else {
       const value = parseInt(this.inputMinutes.value);
       if (value >= 0 && value < 60) {
-        this.inputMinutes.value = String(value);
-        this.drawClockFromTimeInput(value, isHours);
+        this.inputMinutes.value = Timepicker._addLeadingZero(value);
         this.minutes = value;
       }
-      else {
-        const minutes = new Date().getMinutes();
-        this.inputMinutes.value = Timepicker._addLeadingZero(minutes);
+      else if(value == -1) {
+        this.minutes = 59;
+        this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes.toString());
       }
+      else {
+        this.minutes = 0;
+        this.inputMinutes.value = Timepicker._addLeadingZero(this.minutes);
+      }
+      this.drawClockFromTimeInput(value, isHours);
     }
   }
 
@@ -811,9 +819,9 @@ export class Timepicker extends Component<TimepickerOptions> {
           <div class="timepicker-digital-display">
             <div class="timepicker-text-container">
               <div class="timepicker-display-column">
-                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary" min="1" max="12"/>
+                <input type="number" maxlength="2" autofocus class="timepicker-input-hours text-primary"/>
                 :
-                <input type="number" maxlength="2" class="timepicker-input-minutes" min="0" max="59"/>
+                <input type="number" maxlength="2" class="timepicker-input-minutes"/>
               </div>
               <div class="timepicker-display-column timepicker-display-am-pm">
                 <div class="timepicker-span-am-pm"></div>


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Fixes & enhancements based on https://github.com/materializecss/materialize/issues/476

- [X] Layout mismatch on mobile spec
- [X] Layout light theme: color mismatch on input fields in timepicker component
- [X] Event listeners: Refactored click listeners to focus listener, this is more specific and detects focus by keyboard tabbing
- [X] Input hours field: fix leading zero's consistency
- [X] Input hours/minutes: introduced focusout event listener, moved leading zero's to focusout event listener since they are interrupting keyboard input and reduce accessibility
- [X] Extend twelveHour option in inputFromTextField method
- [X] Remove autofocus on change since it's interrupting keyboard input and reduce accessibility
- [X] Make submit/cancel buttons more accessible, introduce focussability and tabbability
- [X] Fix bug in 24hour user input where hand was not placed correctly on analog clock when changing clock value manually in digital display

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [] My change requires a change to the documentation, and updated it accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
