### PR TITLE
Tabs with Icons

### DIFF
--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -51,6 +51,41 @@
   margin: 0 auto;
   white-space: nowrap;
 
+  &.tabs-vertical {
+    height: 64px;
+    .tab {
+      height: 64px;
+
+      i.material-icons {
+        position: relative;
+        top: 8px;
+        vertical-align: middle;  
+      }
+
+      a {
+        display: flex;
+        flex-direction: column;        
+      }
+
+    
+
+      span {
+        height: 24px;
+        line-height: 20px;
+      }
+    }
+  }
+
+  &.tabs-horizontal .tab {    
+    i.material-icons {
+      padding: 0 4px;
+      position: relative;
+      top: -2px;
+      vertical-align: middle;
+    
+    }
+  }
+
   .tab {
     padding-left: 0;
     list-style-type: none;
@@ -60,6 +95,11 @@
     height: 48px;
     padding: 0;
     margin: 0;
+
+    i.material-icons {
+      position: relative;
+      top: 4px;      
+    }
 
     a {
       &.active {

--- a/sass/components/_tabs.scss
+++ b/sass/components/_tabs.scss
@@ -44,61 +44,30 @@
 
   position: relative;
   overflow-x: auto;
-  overflow-y: hidden;
-  height: 48px;
+  overflow-y: hidden;  
   width: 100%;
   background-color: var(--md-sys-color-surface);
   margin: 0 auto;
   white-space: nowrap;
-
-  &.tabs-vertical {
-    height: 64px;
-    .tab {
-      height: 64px;
-
-      i.material-icons {
-        position: relative;
-        top: 8px;
-        vertical-align: middle;  
-      }
-
-      a {
-        display: flex;
-        flex-direction: column;        
-      }
-
-    
-
-      span {
-        height: 24px;
-        line-height: 20px;
-      }
-    }
-  }
-
-  &.tabs-horizontal .tab {    
-    i.material-icons {
-      padding: 0 4px;
-      position: relative;
-      top: -2px;
-      vertical-align: middle;
-    
-    }
-  }
 
   .tab {
     padding-left: 0;
     list-style-type: none;
     display: inline-block;
     text-align: center;
-    line-height: 48px;
-    height: 48px;
+    line-height: 48px;    
     padding: 0;
     margin: 0;
 
     i.material-icons {
       position: relative;
-      top: 4px;      
+      top: 8px;      
+      vertical-align: middle;        
+    }
+
+    span {
+      height: 24px;
+      line-height: 20px;
     }
 
     a {
@@ -123,9 +92,11 @@
       }
 
       color: var(--md-sys-color-on-surface-variant);
-      display: block;
+      display: flex;
+      flex-direction: column;  
       width: 100%;
       height: 100%;
+      min-height: 48px;  //needed for only-icons tabs
       padding: 0 24px;
       font-size: 14px;
       text-overflow: ellipsis;
@@ -151,6 +122,21 @@
     background-color: var(--md-sys-color-primary);
     will-change: left, right;
     border-radius: 3px 3px 0 0;
+  }
+  
+  &.tabs-horizontal .tab { 
+    height: 48px;
+
+    a {
+      display: block;
+    }
+   
+    i.material-icons {
+      padding: 0 4px;
+      position: relative;      
+      top: -2px;            
+      vertical-align: middle;    
+    }
   }
 }
 

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -131,8 +131,16 @@ export class Tabs extends Component<TabsOptions> {
   }
 
   _handleTabClick = (e: MouseEvent) => {
-    const tabLink = e.target as HTMLAnchorElement;
-    const tab = tabLink.parentElement;
+    let tabLink = e.target as HTMLAnchorElement;
+
+    if (!tabLink)
+      return;
+    var tab = tabLink.parentElement;  
+    while (tab && !tab.classList.contains('tab')) {
+      tabLink = tabLink.parentElement as HTMLAnchorElement;
+      tab = tab.parentElement;
+    }
+    
     // Handle click on tab link only
     if (!tabLink || !tab.classList.contains('tab')) return;
     // is disabled?


### PR DESCRIPTION
## Proposed changes
Adding the options to include icons to tabs.
Changes:
- css rules for vertial and horizontal text positions
- fix for a small issue of tab not being selected when the icon was clicked.
- updated documentation (in a separated PR in materialize-docs)

Note:
Following [M3 Tabs specification](https://m3.material.io/components/tabs/overview), tabs appear vertically-centered by default. 


## Screenshots (if appropriate) or codepen:
![imagen](https://github.com/user-attachments/assets/af7c7847-f7aa-480c-8a25-1896726822fc)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).


- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ ] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly. (Done)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

