### PR TITLE
fix(Datepicker): text overflow - month and year not fully visible

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -38,6 +38,11 @@
     }
   }
 
+  .select-dropdown {
+    padding: 0;
+    vertical-align: middle;
+  }
+
   .select-year input {
     width: 50px;
   }
@@ -59,6 +64,7 @@
 }
 
 .month-prev, .month-next {
+  height: 49px;
   margin-top: 4px;
   cursor: pointer;
   background-color: transparent;


### PR DESCRIPTION
## Proposed changes
Added additional CSS specs to fix month and year overflow issue as described in #512 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
