### PR TITLE
enhancement(Datepicker) date range

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -38,6 +38,11 @@
     }
   }
 
+  .select-dropdown {
+    padding: 0;
+    vertical-align: middle;
+  }
+
   .select-year input {
     width: 50px;
   }
@@ -59,6 +64,7 @@
 }
 
 .month-prev, .month-next {
+  height: 49px;
   margin-top: 4px;
   cursor: pointer;
   background-color: transparent;

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -41,7 +41,7 @@ describe('Datepicker Plugin', () => {
     it('can have a string format', (done) => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
-      M.Datepicker.init(input, { format: 'mm/dd/yyyy' }).open();
+      M.Datepicker.init(input, { format: 'mm/dd/yyyy' });
       const datepicker = M.Datepicker.getInstance(input);
       datepicker.open();
       setTimeout(() => {
@@ -50,10 +50,9 @@ describe('Datepicker Plugin', () => {
         document.querySelector('.datepicker-done').click();
         setTimeout(() => {
           const year = today.getFullYear();
-          let month = today.getMonth() + 1;
-          month = month < 10 ? `0${month}` : month;
+          const month = today.getMonth() + 1;
           const value = datepicker.toString();
-          expect(value).toEqual(`${month}/01/${year}`);
+          expect(value).toEqual(`${month < 10 ? `0${month}` : month}/01/${year}`);
           done();
         }, 400);
       }, 400);
@@ -63,7 +62,7 @@ describe('Datepicker Plugin', () => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
       const formatFn = `${today.getFullYear() - 100}-${today.getMonth() + 1}-99`;
-      M.Datepicker.init(input, { format: formatFn }).open();
+      M.Datepicker.init(input, { format: formatFn });
       const datepicker = M.Datepicker.getInstance(input);
       datepicker.open();
       setTimeout(() => {
@@ -73,7 +72,7 @@ describe('Datepicker Plugin', () => {
         setTimeout(() => {
           const year = today.getFullYear() - 100;
           const month = today.getMonth() + 1;
-          expect(datepicker.toString()).toEqual(`${year}-${month}-99`);
+          expect(datepicker.toString()).toEqual(`${year}-${month < 10 ? `0${month}` : month}-99`);
           done();
         }, 400);
       }, 400);

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -7,14 +7,16 @@ describe('Datepicker Plugin', () => {
   </div>
 </div>`;
 
-  beforeEach(() => {
-    XloadHtml(fixture);
-    M.Datepicker.init(document.querySelectorAll('.datepicker'));
-  });
+  beforeEach(() => XloadHtml(fixture));
   afterEach(() => XunloadFixtures());
 
   describe('Datepicker', () => {
+    afterEach(() => {
+      M.Datepicker.getInstance(document.querySelector('.datepicker')).destroy();
+    });
+
     it('should open and close programmatically', (done) => {
+      M.Datepicker.init(document.querySelectorAll('.datepicker'));
       const input = document.querySelector('#datepickerInput');
       const modal = document.querySelector('.datepicker-modal');
       expect(modal).toBeHidden('Should be hidden before datepicker input is focused.');
@@ -40,15 +42,17 @@ describe('Datepicker Plugin', () => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
       M.Datepicker.init(input, { format: 'mm/dd/yyyy' }).open();
-      M.Datepicker.getInstance(input).open();
+      const datepicker = M.Datepicker.getInstance(input);
+      datepicker.open();
       setTimeout(() => {
         const day1 = document.querySelector('.datepicker-modal button[data-day="1"]');
         day1.click();
+        document.querySelector('.datepicker-done').click();
         setTimeout(() => {
           const year = today.getFullYear();
           let month = today.getMonth() + 1;
           month = month < 10 ? `0${month}` : month;
-          const value = M.Datepicker.getInstance(input).toString();
+          const value = datepicker.toString();
           expect(value).toEqual(`${month}/01/${year}`);
           done();
         }, 400);
@@ -58,17 +62,18 @@ describe('Datepicker Plugin', () => {
     it('can have a format function', (done) => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
-      const formatFn = (date) => `${date.getFullYear() - 100}-${date.getMonth() + 1}-99`;
+      const formatFn = `${today.getFullYear() - 100}-${today.getMonth() + 1}-99`;
       M.Datepicker.init(input, { format: formatFn }).open();
-      M.Datepicker.getInstance(input).open();
+      const datepicker = M.Datepicker.getInstance(input);
+      datepicker.open();
       setTimeout(() => {
         const day1 = document.querySelector('.datepicker-modal button[data-day="1"]');
         day1.click();
+        document.querySelector('.datepicker-done').click();
         setTimeout(() => {
           const year = today.getFullYear() - 100;
           const month = today.getMonth() + 1;
-          const value = M.Datepicker.getInstance(input).toString();
-          expect(value).toEqual(`${year}-${month}-99`);
+          expect(datepicker.toString()).toEqual(`${year}-${month}-99`);
           done();
         }, 400);
       }, 400);

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -104,5 +104,14 @@ describe('Datepicker Plugin', () => {
         done();
       }, 10);
     });
+
+    it('should have a date range input field if date range option is enabled', (done) => {
+      const input = document.querySelector('#datepickerInput');
+      M.Datepicker.init(input, { isDateRange: true });
+      setTimeout(() => {
+        expect(document.querySelector('.datepicker-end-date')).toExist('end date input should exist');
+        done();
+      }, 10);
+    });
   });
 });

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -77,5 +77,32 @@ describe('Datepicker Plugin', () => {
         }, 400);
       }, 400);
     });
+
+    it('can change the calendar modal selected date by input', (done) => {
+      const input = document.querySelector('#datepickerInput');
+      M.Datepicker.init(input, { format: 'mm/dd/yyyy' });
+      const today = new Date();
+      let month = today.getMonth();
+      const year = today.getFullYear() - 44;
+      const day = 11;
+      input.value = `${month < 10 ? `0${month}` : month}/${day}/${year}`;
+      input.dispatchEvent(
+        new Event('change', { bubbles: true, cancelable: true })
+      );
+      keydown(input, 13);
+      setTimeout(() => {
+        expect(document.querySelector('.datepicker-modal')).toHaveClass(
+          'open',
+          'modal should be shown after input is submitted.'
+        );
+        const selectMonthElem = document.querySelector('.datepicker-select.orig-select-month');
+        const selectYearElem = document.querySelector('.datepicker-select.orig-select-year');
+        const selectedDayElem = document.querySelector(`.datepicker-row td[data-day="${day}"]`);
+        expect(selectMonthElem.querySelector('option[selected="selected"]').value === (month -1).toString()).toEqual(true, `selected month should be ${month}, given value ${selectMonthElem.querySelector('option[selected="selected"]').value}`)
+        expect(selectYearElem.querySelector('option[selected="selected"]').value === year.toString()).toEqual(true, `selected year should be ${year}, given value ${selectYearElem.querySelector('option[selected="selected"]').value}`)
+        expect(selectedDayElem.classList.contains('is-selected')).toEqual(true, `selected day should be ${day}, given value ${selectedDayElem.classList}`);
+        done();
+      }, 10);
+    });
   });
 });

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -87,7 +87,7 @@ describe('Datepicker Plugin', () => {
       const day = 11;
       input.value = `${month < 10 ? `0${month}` : month}/${day}/${year}`;
       input.dispatchEvent(
-        new Event('change', { bubbles: true, cancelable: true })
+        new KeyboardEvent('change', { bubbles: true, cancelable: true })
       );
       keydown(input, 13);
       setTimeout(() => {
@@ -98,8 +98,8 @@ describe('Datepicker Plugin', () => {
         const selectMonthElem = document.querySelector('.datepicker-select.orig-select-month');
         const selectYearElem = document.querySelector('.datepicker-select.orig-select-year');
         const selectedDayElem = document.querySelector(`.datepicker-row td[data-day="${day}"]`);
-        expect(selectMonthElem.querySelector('option[selected="selected"]').value === (month -1).toString()).toEqual(true, `selected month should be ${month}, given value ${selectMonthElem.querySelector('option[selected="selected"]').value}`)
-        expect(selectYearElem.querySelector('option[selected="selected"]').value === year.toString()).toEqual(true, `selected year should be ${year}, given value ${selectYearElem.querySelector('option[selected="selected"]').value}`)
+        expect(selectMonthElem.querySelector('option[selected="selected"]').value === (month - 1).toString()).toEqual(true, `selected month should be ${month}, given value ${selectMonthElem.querySelector('option[selected="selected"]').value}`);
+        expect(selectYearElem.querySelector('option[selected="selected"]').value === year.toString()).toEqual(true, `selected year should be ${year}, given value ${selectYearElem.querySelector('option[selected="selected"]').value}`);
         expect(selectedDayElem.classList.contains('is-selected')).toEqual(true, `selected day should be ${day}, given value ${selectedDayElem.classList}`);
         done();
       }, 10);

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -1147,8 +1147,11 @@ export class Datepicker extends Component<DatepickerOptions> {
 
   _handleInputChange = (e: Event) => {
     let date;
+    const el = (e.target as HTMLElement);
     // Prevent change event from being fired when triggered by the plugin
     if (e['detail']?.firedBy === this) return;
+    // Prevent change event from being fired if an end date is set without a start date
+    if(el == this.endDateEl && !this.date) return;
     if (this.options.parse) {
       date = this.options.parse((e.target as HTMLInputElement).value,
         typeof this.options.format === "function"
@@ -1159,7 +1162,7 @@ export class Datepicker extends Component<DatepickerOptions> {
       date = new Date(Date.parse((e.target as HTMLInputElement).value));
     }
     if (Datepicker._isDate(date)) {
-      this.setDate(date, false, (e.target as HTMLElement) == this.endDateEl);
+      this.setDate(date, false, el == this.endDateEl);
       if (e.type == 'date') {
         this.setDataDate(e, date);
         this.setInputValues();

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -1,7 +1,7 @@
-import { Modal } from "./modal";
-import { Utils } from "./utils";
-import { FormSelect } from "./select";
-import { BaseOptions, Component, InitElements, MElement, I18nOptions } from "./component";
+import { Modal } from './modal';
+import { Utils } from './utils';
+import { FormSelect } from './select';
+import { BaseOptions, Component, I18nOptions, InitElements, MElement } from './component';
 
 export interface DateI18nOptions extends I18nOptions {
   previousMonth: string;
@@ -485,10 +485,9 @@ export class Datepicker extends Component<DatepickerOptions> {
    */
   formatDate(date: Date, format: string) {
     const formatArray = format.split(/(d{1,4}|m{1,4}|y{4}|yy|!.)/g);
-    const formattedDate = formatArray
+    return formatArray
       .map(label => this.formats[label] ? this.formats[label](date) : label)
       .join('');
-    return formattedDate;
   }
 
   /**
@@ -674,7 +673,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     for (let i = 0, r = 0; i < cells; i++) {
       let day = new Date(year, month, 1 + (i - before)),
         isToday = Datepicker._compareDates(day, now),
-        hasEvent = opts.events.indexOf(day.toDateString()) !== -1 ? true : false,
+        hasEvent = opts.events.indexOf(day.toDateString()) !== -1,
         isEmpty = i < before || i >= days + before,
         dayNumber = 1 + (i - before),
         monthNumber = month,
@@ -1058,8 +1057,8 @@ export class Datepicker extends Component<DatepickerOptions> {
     if(e.type == 'date') {
       e.preventDefault()
     }
-    this.open();
     this.setDateFromInput(e.target as HTMLInputElement);
+    this.open();
     this.gotoDate(<HTMLElement>(e.target) === this.el ? this.date : this.endDate);
   }
 


### PR DESCRIPTION
## Proposed changes
**Implemented date range select functionality as per pull-request #360** 
- This functionality adds an end date field when option `dateRange: true` is provided
- Implemented calendar modal functionality to select an end date
- Implemented end field input change handling and modifiers to adjust the year, month and day selectors if a click or enter keypress interaction is executed
- Daterange classes added for in-range days
_styling of the in-range items needs to be addressed, propose create this in a new issue since the global layout of the datepicker is outdated: currently still follows the M2 guidelines_

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
