### PR TITLE
enhancement(Datepicker) styling refactor

### DIFF
--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -1,8 +1,9 @@
 /* Modal */
 .datepicker-modal {
   max-width: 325px;
-  min-width: 300px;
-  max-height: none;
+  // @removed since v2.2.1-dev regarding Material M3 standards
+  /* min-width: 300px;
+  max-height: none; */
 }
 
 .datepicker-container.modal-content {
@@ -75,9 +76,11 @@
 /* Date Display */
 .datepicker-date-display {
   flex: 1 auto;
-  background-color: var(--md-sys-color-primary);
-  color:  var(--md-sys-color-on-primary);
+  // @removed since v2.2.1-dev regarding Material M3 standards
+  // background-color: var(--md-sys-color-primary);
+  // color:  var(--md-sys-color-on-primary);
   padding: 20px 22px;
+  border-bottom: 1px solid var(--md-sys-color-surface-variant-light);
   font-weight: 500;
 
   .year-text {
@@ -124,46 +127,88 @@
     color: var(--md-sys-color-on-surface-variant);
   }
 
-  td {
+  .datepicker-day {
     color: var(--md-sys-color-on-background);
 
     &.is-today {
       color: var(--md-sys-color-primary);
     }
 
-    &.is-selected {
+    /*&.is-selected button {
       background-color: var(--md-sys-color-primary);
       color:  var(--md-sys-color-on-primary);
-    }
+    }*/
 
-    &.is-outside-current-month,
-    &.is-disabled {
-      color: var(--md-sys-color-on-surface);
-      pointer-events: none;
-    }
-
-    border-radius: 50%;
+    // border-radius: 50%;
     padding: 0;
+  }
+}
+
+.datepicker-day.is-inrange {
+  .datepicker-day-container {
+    position: relative;
+    background-color: var(--md-sys-color-primary-container);
+    z-index: 0;
+  }
+
+  // @todo find solution why pseudo selectors are not working or implement other method
+  &:first-child .datepicker-day-container:before,
+  &:last-child .datepicker-day-container:before {
+    position: absolute;
+    height: 100%;
+    width: 50%;
+    content: '';
+    background-color: var(--md-sys-color-primary-container);
+    z-index: 0;
+  }
+
+  &:first-child .datepicker-day-container:before {
+      left: -50%;
+  }
+
+  &:last-child .datepicker-day-container:before {
+    left: auto;
+    right: -50%;
   }
 }
 
 .datepicker-day-button {
   background-color: transparent;
   border: none;
-  line-height: 38px;
+  line-height: 34px;
   display: block;
-  width: 100%;
+  width: 34px;
   border-radius: 50%;
+  margin: 5px;
   padding: 0 5px;
   cursor: pointer;
   color: inherit;
+
+  position: relative;
+  z-index: 1;
 
   &:hover {
     background-color: rgba(var(--md-sys-color-primary-numeric), 0.06);
   }
 
   &:focus {
-    background-color: rgba(var(--md-sys-color-primary-numeric), 0.18);
+    border-color: var(--md-sys-color-primary);
+  }
+
+  .is-selected & {
+    background-color: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+
+    &:focus {
+      background-color: var(--md-sys-color-surface-variant);
+      color: var(--md-sys-color-primary);
+    }
+  }
+
+  &.is-outside-current-month button,
+  &.is-disabled button {
+    color: var(--md-sys-color-on-surface);
+    pointer-events: none;
   }
 }
 
@@ -192,7 +237,8 @@
 
 /* Media Queries */
 @media #{$medium-and-up} {
-  .datepicker-modal {
+  @removed since v2.2.1-dev regarding Material M3 standards
+  /*.datepicker-modal {
     max-width: 625px;
   }
 
@@ -208,7 +254,7 @@
   .datepicker-table,
   .datepicker-footer {
     width: 320px;
-  }
+  }*/
 
   .datepicker-day-button {
     line-height: 44px;

--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -1,14 +1,16 @@
 /* Modal */
-.datepicker-modal {
+// @removed since v2.2.1
+/*.datepicker-modal {
   max-width: 325px;
   // @removed since v2.2.1-dev regarding Material M3 standards
-  /* min-width: 300px;
-  max-height: none; */
-}
+  min-width: 300px;
+  max-height: none;
+}*/
 
-.datepicker-container.modal-content {
+.datepicker-container {
   display: flex;
   flex-direction: column;
+  max-width: 325px;
   padding: 0;
   background-color: var(--md-sys-color-surface);
 }
@@ -238,7 +240,7 @@
 
 /* Media Queries */
 @media #{$medium-and-up} {
-  @removed since v2.2.1-dev regarding Material M3 standards
+  // @removed since v2.2.1-dev regarding Material M3 standards
   /*.datepicker-modal {
     max-width: 625px;
   }

--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -144,32 +144,33 @@
   }
 }
 
-.datepicker-day.is-inrange {
-  .datepicker-day-container {
-    position: relative;
-    background-color: var(--md-sys-color-primary-container);
-    z-index: 0;
-  }
+.datepicker-day.is-daterange-start,
+.datepicker-day.is-daterange-end,
+.datepicker-day.is-daterange {
+  position: relative;
 
-  // @todo find solution why pseudo selectors are not working or implement other method
-  &:first-child .datepicker-day-container:before,
-  &:last-child .datepicker-day-container:before {
+  &:before {
     position: absolute;
-    height: 100%;
-    width: 50%;
+    top: 5px;
+    width: 100%;
+    height: 34px;
     content: '';
     background-color: var(--md-sys-color-primary-container);
     z-index: 0;
   }
+}
 
-  &:first-child .datepicker-day-container:before {
-      left: -50%;
-  }
+.datepicker-day.is-daterange-start:before,
+.datepicker-day.is-daterange-end:before {
+  width: 50%;
+}
 
-  &:last-child .datepicker-day-container:before {
-    left: auto;
-    right: -50%;
-  }
+.datepicker-day.is-daterange-start:before {
+  left: 50%;
+}
+
+.datepicker-day.is-daterange .datepicker-day-button:before {
+  background-color: var(--md-sys-color-primary-container);
 }
 
 .datepicker-day-button {

--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -157,6 +157,15 @@
   }
 }
 
+// @todo
+.datepicker-day.has-event {}
+// @todo
+.datepicker-day.is-inrange {}
+// @todo
+.datepicker-day.is-startrange {}
+// @todo
+.datepicker-day.is-endrange {}
+
 .datepicker-day.is-daterange-start,
 .datepicker-day.is-daterange-end,
 .datepicker-day.is-daterange {

--- a/sass/components/_datepicker.scss
+++ b/sass/components/_datepicker.scss
@@ -46,6 +46,11 @@
     vertical-align: middle;
   }
 
+  .select-year input,
+  .select-month input {
+    background-color: transparent;
+  }
+
   .select-year input {
     width: 50px;
   }
@@ -97,6 +102,12 @@
     font-size: 2.8rem;
     line-height: 47px;
     font-weight: 500;
+  }
+
+  .daterange & {
+    .date-text {
+      font-size: 1.8rem;
+    }
   }
 }
 
@@ -257,9 +268,9 @@
   .datepicker-table,
   .datepicker-footer {
     width: 320px;
-  }*/
+  }
 
   .datepicker-day-button {
     line-height: 44px;
-  }
+  }*/
 }

--- a/spec/tests/datepicker/datepickerSpec.js
+++ b/spec/tests/datepicker/datepickerSpec.js
@@ -16,11 +16,11 @@ describe('Datepicker Plugin', () => {
     it('can have a string format', (done) => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
-      M.Datepicker.init(input, { format: 'mm/dd/yyyy' });
+      M.Datepicker.init(input, { format: 'mm/dd/yyyy', openByDefault: true });
       const datepicker = M.Datepicker.getInstance(input);
       //datepicker.open();
       setTimeout(() => {
-        const day1 = document.querySelector('.datepicker-modal button[data-day="1"]');
+        const day1 = document.querySelector('.datepicker-container button[data-day="1"]');
         day1.click();
         document.querySelector('.datepicker-done').click();
         setTimeout(() => {
@@ -37,11 +37,11 @@ describe('Datepicker Plugin', () => {
       const input = document.querySelector('#datepickerInput');
       const today = new Date();
       const formatFn = `${today.getFullYear() - 100}-${today.getMonth() + 1}-99`;
-      M.Datepicker.init(input, { format: formatFn });
+      M.Datepicker.init(input, { format: formatFn, openByDefault: true });
       const datepicker = M.Datepicker.getInstance(input);
       //datepicker.open();
       setTimeout(() => {
-        const day1 = document.querySelector('.datepicker-modal button[data-day="1"]');
+        const day1 = document.querySelector('.datepicker-container button[data-day="1"]');
         day1.click();
         document.querySelector('.datepicker-done').click();
         setTimeout(() => {
@@ -55,7 +55,7 @@ describe('Datepicker Plugin', () => {
 
     it('can change the calendar modal selected date by input', (done) => {
       const input = document.querySelector('#datepickerInput');
-      M.Datepicker.init(input, { format: 'mm/dd/yyyy' });
+      M.Datepicker.init(input, { format: 'mm/dd/yyyy', openByDefault: true });
       const today = new Date();
       const month = today.getMonth();
       const year = today.getFullYear() - 44;
@@ -73,7 +73,7 @@ describe('Datepicker Plugin', () => {
         const selectedDayElem = document.querySelector(`.datepicker-row td[data-day="${day}"]`);
         expect(
           selectMonthElem.querySelector('option[selected="selected"]').value ===
-            (month - 1).toString()
+          (month - 1).toString()
         ).toEqual(
           true,
           `selected month should be ${month}, given value ${selectMonthElem.querySelector('option[selected="selected"]').value}`
@@ -94,7 +94,7 @@ describe('Datepicker Plugin', () => {
 
     it('should have a date range input field if date range option is enabled', (done) => {
       const input = document.querySelector('#datepickerInput');
-      M.Datepicker.init(input, { isDateRange: true });
+      M.Datepicker.init(input, { isDateRange: true, openByDefault: true });
       setTimeout(() => {
         expect(document.querySelector('.datepicker-end-date')).toExist(
           'end date input should exist'
@@ -105,13 +105,13 @@ describe('Datepicker Plugin', () => {
 
     it('should have multiple input fields if multiple select option is enabled and multiple dates are selected', (done) => {
       const input = document.querySelector('#datepickerInput');
-      M.Datepicker.init(input, { isMultipleSelection: true });
+      M.Datepicker.init(input, { isMultipleSelection: true, openByDefault: true });
       const datepicker = M.Datepicker.getInstance(input);
       datepicker.open();
       setTimeout(() => {
-        for (let i = 1; i < 4; i++) {
+        for (let i = 1; i <= 3; i++) {
           setTimeout(() => {
-            document.querySelector(`.datepicker-modal button[data-day="${i}"]`).click();
+            document.querySelector(`.datepicker-container button[data-day="${i}"]`).click();
           }, i * 10);
         }
         setTimeout(() => {

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -804,7 +804,7 @@ export class Datepicker extends Component<DatepickerOptions> {
   }
 
   renderDay(opts) {
-    const arr = [];
+    const arr = ['datepicker-day'];
     let ariaSelected = 'false';
     if (opts.isEmpty) {
       if (opts.showDaysInNextAndPreviousMonths) {
@@ -834,9 +834,9 @@ export class Datepicker extends Component<DatepickerOptions> {
       arr.push('has-event');
     }
 
-    // @todo should we create this additional css class?
     if (opts.isInRange) {
       arr.push('is-inrange');
+      ariaSelected = 'true';
     }
 
     // @todo should we create this additional css class?
@@ -855,7 +855,9 @@ export class Datepicker extends Component<DatepickerOptions> {
     }
     return (
       `<td data-day="${opts.day}" class="${arr.join(' ')}" aria-selected="${ariaSelected}">` +
+        '<div class="datepicker-day-container">' +
       `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${opts.month}" data-day="${opts.day}">${opts.day}</button>` +
+        '</div>' +
       '</td>'
     );
   }
@@ -955,7 +957,8 @@ export class Datepicker extends Component<DatepickerOptions> {
       '<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"/><path d="M0-.5h24v24H0z" fill="none"/></svg>';
     html += `<button class="month-prev${
       prev ? '' : ' is-disabled'
-    } btn-flat" type="button">${leftArrow}</button>`;
+      // @todo remove button class and add scss mixin, current implementation temporary for focus states, @see https://github.com/materializecss/materialize/issues/566
+    } btn" type="button">${leftArrow}</button>`;
 
     html += '<div class="selects-container">';
     if (opts.showMonthAfterYear) {
@@ -977,7 +980,8 @@ export class Datepicker extends Component<DatepickerOptions> {
       '<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"/><path d="M0-.25h24v24H0z" fill="none"/></svg>';
     html += `<button class="month-next${
       next ? '' : ' is-disabled'
-    } btn-flat" type="button">${rightArrow}</button>`;
+      // @todo remove button class and add scss mixin, current implementation temporary for focus states, @see https://github.com/materializecss/materialize/issues/566
+    } btn" type="button">${rightArrow}</button>`;
 
     return (html += '</div>');
   }
@@ -1035,6 +1039,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     // Init Materialize Select
     const yearSelect = this.calendarEl.querySelector('.orig-select-year') as HTMLSelectElement;
     const monthSelect = this.calendarEl.querySelector('.orig-select-month') as HTMLSelectElement;
+    // @todo fix accessibility @see https://github.com/materializecss/materialize/issues/522
     FormSelect.init(yearSelect, {
       classes: 'select-year',
       dropdownOptions: { container: document.body, constrainWidth: false }

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -260,7 +260,7 @@ export class Datepicker extends Component<DatepickerOptions> {
   doneBtn: HTMLElement;
   cancelBtn: HTMLElement;
 
-  modalEl: HTMLElement;
+  containerEl: HTMLElement;
   yearTextEl: HTMLElement;
   dateTextEl: HTMLElement;
   endDateEl: HTMLInputElement;
@@ -409,7 +409,7 @@ export class Datepicker extends Component<DatepickerOptions> {
 
   destroy() {
     this._removeEventHandlers();
-    this.modalEl.remove();
+    this.containerEl.remove();
     this.destroySelects();
     this.el['M_Datepicker'] = undefined;
   }
@@ -447,10 +447,11 @@ export class Datepicker extends Component<DatepickerOptions> {
       const optEl = this.options.container;
       this.options.container =
         optEl instanceof HTMLElement ? optEl : (document.querySelector(optEl) as HTMLElement);
-      this.options.container.append(this.modalEl);
+      this.options.container.append(this.containerEl);
     } else {
-      //this.modalEl.before(this.el);
-      this.el.parentElement.appendChild(this.modalEl);
+      //this.containerEl.before(this.el);
+      const appendTo = !this.endDateEl ? this.el : this.endDateEl;
+      appendTo.parentElement.after(this.containerEl);
     }
   }
 
@@ -859,7 +860,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     }
 
     if (opts.isDateRangeEnd) {
-      arr.push('is-daterang-eend');
+      arr.push('is-daterange-end');
     }
 
     if (opts.isDateRange) {
@@ -1085,17 +1086,17 @@ export class Datepicker extends Component<DatepickerOptions> {
     const template = document.createElement('template');
     template.innerHTML = Datepicker._template.trim();
 
-    this.modalEl = <HTMLElement>template.content.firstChild;
+    this.containerEl = <HTMLElement>template.content.firstChild;
 
-    this.calendarEl = this.modalEl.querySelector('.datepicker-calendar');
-    this.yearTextEl = this.modalEl.querySelector('.year-text');
-    this.dateTextEl = this.modalEl.querySelector('.date-text');
+    this.calendarEl = this.containerEl.querySelector('.datepicker-calendar');
+    this.yearTextEl = this.containerEl.querySelector('.year-text');
+    this.dateTextEl = this.containerEl.querySelector('.date-text');
     if (this.options.showClearBtn) {
-      this.clearBtn = this.modalEl.querySelector('.datepicker-clear');
+      this.clearBtn = this.containerEl.querySelector('.datepicker-clear');
     }
     // TODO: This should not be part of the datepicker
-    this.doneBtn = this.modalEl.querySelector('.datepicker-done');
-    this.cancelBtn = this.modalEl.querySelector('.datepicker-cancel');
+    this.doneBtn = this.containerEl.querySelector('.datepicker-done');
+    this.cancelBtn = this.containerEl.querySelector('.datepicker-cancel');
 
     this.formats = {
       d: (date: Date) => {
@@ -1305,8 +1306,7 @@ export class Datepicker extends Component<DatepickerOptions> {
 
   static {
     Datepicker._template = `
-      <div class="datepicker-modal">
-        <div class="modal-content datepicker-container">
+        <div class="datepicker-container">
           <div class="datepicker-date-display">
             <span class="year-text"></span>
             <span class="date-text"></span>
@@ -1321,7 +1321,6 @@ export class Datepicker extends Component<DatepickerOptions> {
               </div>
             </div>
           </div>
-        </div>
-      </div>`;
+        </div>`;
   }
 }

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -739,6 +739,8 @@ export class Datepicker extends Component<DatepickerOptions> {
           (this.options.maxDate && day > this.options.maxDate) ||
           (this.options.disableWeekends && Datepicker._isWeekend(day)) ||
           (this.options.disableDayFn && this.options.disableDayFn(day)),
+        isDateRangeStart = this.options.isDateRange && Datepicker._compareDates(this.date, day),
+        isDateRangeEnd = this.options.isDateRange && Datepicker._compareDates(this.endDate, day),
         isDateRange =
           this.options.isDateRange &&
           Datepicker._isDate(this.endDate) &&
@@ -788,6 +790,8 @@ export class Datepicker extends Component<DatepickerOptions> {
         isEndRange: isEndRange,
         isInRange: isInRange,
         showDaysInNextAndPreviousMonths: this.options.showDaysInNextAndPreviousMonths,
+        isDateRangeStart: isDateRangeStart,
+        isDateRangeEnd: isDateRangeEnd,
         isDateRange: isDateRange
       };
 
@@ -834,6 +838,7 @@ export class Datepicker extends Component<DatepickerOptions> {
       arr.push('has-event');
     }
 
+    // @todo create additional css class
     if (opts.isInRange) {
       arr.push('is-inrange');
       ariaSelected = 'true';
@@ -849,15 +854,20 @@ export class Datepicker extends Component<DatepickerOptions> {
       arr.push('is-endrange');
     }
 
-    // @todo create additional css class
+    if (opts.isDateRangeStart) {
+      arr.push('is-daterange-start');
+    }
+
+    if (opts.isDateRangeEnd) {
+      arr.push('is-daterang-eend');
+    }
+
     if (opts.isDateRange) {
       arr.push('is-daterange');
     }
     return (
       `<td data-day="${opts.day}" class="${arr.join(' ')}" aria-selected="${ariaSelected}">` +
-        '<div class="datepicker-day-container">' +
       `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${opts.month}" data-day="${opts.day}">${opts.day}</button>` +
-        '</div>' +
       '</td>'
     );
   }

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -453,6 +453,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     }
 
     if (this.options.isDateRange) {
+      this.containerEl.classList.add('daterange');
       if (!this.options.dateRangeEndEl) {
         this.endDateEl = this.createDateInput();
         this.endDateEl.classList.add('datepicker-end-date');

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -143,7 +143,11 @@ export interface DatepickerOptions extends BaseOptions {
    * @default null
    */
   onDraw: (() => void) | null;
-
+  /**
+   * Callback function for interaction with input field.
+   * @default null
+   */
+  onInputInteraction: (() => void) | null;
   /** Field used for internal calculations DO NOT CHANGE IT */
   minYear?: number;
   /** Field used for internal calculations DO NOT CHANGE IT */
@@ -245,7 +249,8 @@ const _defaults: DatepickerOptions = {
   events: [],
   // callback function
   onSelect: null,
-  onDraw: null
+  onDraw: null,
+  onInputInteraction: null,
 };
 
 export class Datepicker extends Component<DatepickerOptions> {
@@ -1154,6 +1159,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     this.setDateFromInput(e.target as HTMLInputElement);
     this.draw();
     this.gotoDate(<HTMLElement>e.target === this.el ? this.date : this.endDate);
+    if (this.options.onInputInteraction) this.options.onInputInteraction.call(this);
   };
 
   _handleInputKeydown = (e: KeyboardEvent) => {
@@ -1161,6 +1167,7 @@ export class Datepicker extends Component<DatepickerOptions> {
       e.preventDefault();
       this.setDateFromInput(e.target as HTMLInputElement);
       this.draw();
+      if (this.options.onInputInteraction) this.options.onInputInteraction.call(this);
     }
   };
 

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -111,6 +111,10 @@ export interface DatepickerOptions extends BaseOptions {
    */
   showDaysInNextAndPreviousMonths: boolean;
   /**
+   * Specify if the docked datepicker is in open state by default
+   */
+  openByDefault: boolean;
+  /**
    * Specify a DOM element OR selector for a DOM element to render
    * the calendar in, by default it will be placed before the input.
    * @default null
@@ -208,6 +212,8 @@ const _defaults: DatepickerOptions = {
   showMonthAfterYear: false,
   // Render days of the calendar grid that fall in the next or previous month
   showDaysInNextAndPreviousMonths: false,
+  // Specify if docked picker is in open state by default
+  openByDefault: false,
   // Specify a DOM element to render the calendar in
   container: null,
   // Show clear button
@@ -475,6 +481,7 @@ export class Datepicker extends Component<DatepickerOptions> {
     } else {
       //this.containerEl.before(this.el);
       const appendTo = !this.endDateEl ? this.el : this.endDateEl;
+      if (!this.options.openByDefault) (this.containerEl as HTMLElement).setAttribute('style', 'display: none; visibility: hidden;');
       appendTo.parentElement.after(this.containerEl);
     }
   }

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -448,7 +448,7 @@ export class Datepicker extends Component<DatepickerOptions> {
       this.el.classList.add('datepicker-date-input');
     }
 
-    if (this.el.parentElement.querySelector('.datepicker-format') !== undefined) {
+    if (!this.el.parentElement.querySelector('.datepicker-format') === null) {
       this._renderDateInputFormat(this.el);
     }
 
@@ -460,7 +460,7 @@ export class Datepicker extends Component<DatepickerOptions> {
         console.warn('Specified date range end input element in dateRangeEndEl not found');
       } else {
         this.endDateEl = document.querySelector(this.options.dateRangeEndEl) as HTMLInputElement;
-        if (this.endDateEl.parentElement.querySelector('.datepicker-format') !== undefined) {
+        if (!this.endDateEl.parentElement.querySelector('.datepicker-format') === null) {
           this._renderDateInputFormat(this.endDateEl);
         }
       }

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -442,6 +442,10 @@ export class Datepicker extends Component<DatepickerOptions> {
       this.el.classList.add('datepicker-date-input');
     }
 
+    if (this.el.parentElement.querySelector('.datepicker-format') !== undefined) {
+      this._renderDateInputFormat(this.el);
+    }
+
     if (this.options.isDateRange) {
       if (!this.options.dateRangeEndEl) {
         this.endDateEl = this.createDateInput();
@@ -450,6 +454,9 @@ export class Datepicker extends Component<DatepickerOptions> {
         console.warn('Specified date range end input element in dateRangeEndEl not found');
       } else {
         this.endDateEl = document.querySelector(this.options.dateRangeEndEl) as HTMLInputElement;
+        if (this.endDateEl.parentElement.querySelector('.datepicker-format') !== undefined) {
+          this._renderDateInputFormat(this.endDateEl);
+        }
       }
     }
 
@@ -470,6 +477,13 @@ export class Datepicker extends Component<DatepickerOptions> {
       const appendTo = !this.endDateEl ? this.el : this.endDateEl;
       appendTo.parentElement.after(this.containerEl);
     }
+  }
+
+  /**
+   * Renders the date input format
+   */
+  _renderDateInputFormat(el: HTMLInputElement) {
+    el.parentElement.querySelector('.datepicker-format').innerHTML = this.options.format.toString();
   }
 
   /**

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -643,7 +643,6 @@ export class Datepicker extends Component<DatepickerOptions> {
    * Sets given date as the input value on the given element.
    */
   setInputValue(el, date) {
-    console.log('setinputvalue');
     if (el.type == 'date') {
       this.setDataDate(el, date);
       el.value = this.formatDate(date, 'yyyy-mm-dd');
@@ -848,8 +847,21 @@ export class Datepicker extends Component<DatepickerOptions> {
   }
 
   renderDay(opts) {
-    const arr = ['datepicker-day'];
-    let ariaSelected = 'false';
+    const classMap = {
+        isDisabled: 'is-disabled',
+        isToday: 'is-today',
+        isSelected: 'is-selected',
+        hasEvent: 'has-event',
+        isInRange: 'is-inrange',
+        isStartRange: 'is-startrange',
+        isEndRange: 'is-endrange',
+        isDateRangeStart: 'is-daterange-start',
+        isDateRangeEnd: 'is-daterange-end',
+        isDateRange: 'is-daterange'
+      },
+      ariaSelected = !(['isSelected', 'isDateRange'].filter((prop) => !!(opts.hasOwnProperty(prop) && opts[prop] === true)).length === 0),
+      arr = ['datepicker-day'];
+
     if (opts.isEmpty) {
       if (opts.showDaysInNextAndPreviousMonths) {
         arr.push('is-outside-current-month');
@@ -859,52 +871,12 @@ export class Datepicker extends Component<DatepickerOptions> {
       }
     }
 
-    // @todo wouldn't it be better defining opts class mapping and looping trough opts?
-    if (opts.isDisabled) {
-      arr.push('is-disabled');
+    for (const [property, className] of Object.entries(classMap)) {
+      if (opts.hasOwnProperty(property) && opts[property]) {
+        arr.push(className);
+      }
     }
 
-    if (opts.isToday) {
-      arr.push('is-today');
-    }
-
-    if (opts.isSelected) {
-      arr.push('is-selected');
-      ariaSelected = 'true';
-    }
-
-    // @todo should we create this additional css class?
-    if (opts.hasEvent) {
-      arr.push('has-event');
-    }
-
-    // @todo create additional css class
-    if (opts.isInRange) {
-      arr.push('is-inrange');
-      ariaSelected = 'true';
-    }
-
-    // @todo should we create this additional css class?
-    if (opts.isStartRange) {
-      arr.push('is-startrange');
-    }
-
-    // @todo should we create this additional css class?
-    if (opts.isEndRange) {
-      arr.push('is-endrange');
-    }
-
-    if (opts.isDateRangeStart) {
-      arr.push('is-daterange-start');
-    }
-
-    if (opts.isDateRangeEnd) {
-      arr.push('is-daterange-end');
-    }
-
-    if (opts.isDateRange) {
-      arr.push('is-daterange');
-    }
     return (
       `<td data-day="${opts.day}" class="${arr.join(' ')}" aria-selected="${ariaSelected}">` +
       `<button class="datepicker-day-button" type="button" data-year="${opts.year}" data-month="${opts.month}" data-day="${opts.day}">${opts.day}</button>` +

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -31,6 +31,10 @@ export interface DatepickerOptions extends BaseOptions {
    */
   isDateRange: boolean;
   /**
+   * The selector of the user specified date range end element
+   */
+  dateRangeEndEl: string | null;
+  /**
    * The initial condition if the datepicker is based on multiple date selection.
    * @default false
    */
@@ -169,6 +173,8 @@ const _defaults: DatepickerOptions = {
   parse: null,
   // The initial condition if the datepicker is based on date range
   isDateRange: false,
+  // The selector of the user specified date range end element
+  dateRangeEndEl: null,
   // The initial condition if the datepicker is based on multiple date selection
   isMultipleSelection: false,
   // The initial date to view when first opened
@@ -437,8 +443,14 @@ export class Datepicker extends Component<DatepickerOptions> {
     }
 
     if (this.options.isDateRange) {
-      this.endDateEl = this.createDateInput();
-      this.endDateEl.classList.add('datepicker-end-date');
+      if (!this.options.dateRangeEndEl) {
+        this.endDateEl = this.createDateInput();
+        this.endDateEl.classList.add('datepicker-end-date');
+      } else if(document.querySelector(this.options.dateRangeEndEl) as HTMLInputElement === undefined) {
+        console.warn('Specified date range end input element in dateRangeEndEl not found');
+      } else {
+        this.endDateEl = document.querySelector(this.options.dateRangeEndEl) as HTMLInputElement;
+      }
     }
 
     if (this.options.showClearBtn) {
@@ -745,8 +757,8 @@ export class Datepicker extends Component<DatepickerOptions> {
           (this.options.maxDate && day > this.options.maxDate) ||
           (this.options.disableWeekends && Datepicker._isWeekend(day)) ||
           (this.options.disableDayFn && this.options.disableDayFn(day)),
-        isDateRangeStart = this.options.isDateRange && Datepicker._compareDates(this.date, day),
-        isDateRangeEnd = this.options.isDateRange && Datepicker._compareDates(this.endDate, day),
+        isDateRangeStart = this.options.isDateRange && this.date && this.endDate && Datepicker._compareDates(this.date, day),
+        isDateRangeEnd = this.options.isDateRange && this.endDate && Datepicker._compareDates(this.endDate, day),
         isDateRange =
           this.options.isDateRange &&
           Datepicker._isDate(this.endDate) &&


### PR DESCRIPTION
## Proposed changes
This issue is a follow up of #558, making great steps towards a M3 compatible datepicker

**Changelog**
Removed all modal related selectors #525 
Refactored styling, removed flex row styling so left face gets on top #558 
Refactored tag selectors to class selectors since it has advantages on specificity #558 
Implemented date range styling #360 
Implemented ability to use user defined end date input field via option `dateRangeEndEl: <selector>` #360 
Implemented option `openByDefault` #558 
Implemented input field interaction callback function #525 
Implemented functionality to render date format below the field in the input field supporting text section #558

**Todos**
Handling toggling visibility of the docked picker since open and close is deprecated since v2.2.1 and the event handlers inside the component for handling the interaction open/close should be removed, discussion in #570 about making a global utility function with callback function so it's reusable with multiple components

**Examples**
Implement datepicker with user defined end date element and supporting text for rendering format:
```
<div class="input-field datepicker-field">
    <input type="text" class="datepicker" id="datepicker">
    <label for="datepicker">Date</label>
    <span class="supporting-text datepicker-format"></span>
</div>
<div class="input-field datepicker-field">
    <input type="text" class="datepicker-end-date" id="datepicker-end-date">
    <label for="datepicker-end-date">End date</label>
    <span class="supporting-text datepicker-format"></span>
</div>
```

```M.Datepicker.init(document.querySelector('.datepicker'), { isDateRange: true, dateRangeEndEl: '.datepicker-end-date' })```

Currently we can work with the callback function for opening and closing in modal (or any specified user element) by using the container option

```<dialog class="modal" style="width: 325px"></dialog>```

```
M.Datepicker.init(input, {
    container: '.modal',
    onInputInteraction: () => {
        toggleModal();
    }
});

const modal = document.querySelector('.modal');
toggleModal = () => {
    if (!modal.hasAttribute('open')) {
        modal.setAttribute('open', 'true');
    } else {
        modal.removeAttribute('open');
    }
}
```

This could also work with the docked Datepicker in `openByDefault: false` state with following example, but would additionally require the cancel/confirm buttons to work, propose to follow up the docked datepicker in #140 after #570 is cleared out

```
const datepickerContainer = M.Datepicker.getInstance(input);
toggleVisibility = () => {
    if (!!datepickerContainer.containerEl.style.visibility === true) {
        datepickerContainer.containerEl.removeAttribute('style');
    }
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
