### PR TITLE
enhancement(Autocomplete) allow default selected option(s)

### DIFF
--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -66,6 +66,10 @@ export interface AutocompleteOptions extends BaseOptions {
    * @default {}
    */
   dropdownOptions: Partial<DropdownOptions>;
+  /**
+   * Predefined selected values
+   */
+  selected: number[];
 }
 
 const _defaults: AutocompleteOptions = {
@@ -90,7 +94,8 @@ const _defaults: AutocompleteOptions = {
     );
   },
   maxDropDownHeight: '300px',
-  allowUnsafeHTML: false
+  allowUnsafeHTML: false,
+  selected: []
 };
 
 export class Autocomplete extends Component<AutocompleteOptions> {
@@ -124,7 +129,7 @@ export class Autocomplete extends Component<AutocompleteOptions> {
     this.count = 0;
     this.activeIndex = -1;
     this.oldVal = '';
-    this.selectedValues = [];
+    this.selectedValues = this.selectedValues || this.options.selected.map((value) => <AutocompleteData>{ id: value }) || [];
     this.menuItems = this.options.data || [];
     this.$active = null;
     this._mousedown = false;
@@ -378,6 +383,9 @@ export class Autocomplete extends Component<AutocompleteOptions> {
       'display:grid; grid-auto-flow: column; user-select: none; align-items: center;'
     );
     // Checkbox
+    if(!this.options.isMultiSelect && this.options.selected) {
+      this.selectOption(this.selectedValues.map((value) => value.id)[0]);
+    }
     if (this.options.isMultiSelect) {
       item.innerHTML = `
         <div class="item-selection" style="text-align:center;">


### PR DESCRIPTION
## Proposed changes
This enhancement allows default selected for single or multiselect, as requested per #479
I have implemented an additional option `selected` that allows an array of numbers, given the items numeric ids
This implementation maps the `selected` ids in the `selectedValues` object array and handles selection of single or multiple items

Example single select:
```
M.Autocomplete.init(document.querySelector('.autocomplete'), {
    data: [
        {id: 1, text: "Item 1"},
        {id: 2, text: "Item 2"},
        {id: 3, text: "Item 3"}
    ],
    selected: [3]
});
```

Example multi select:
```
M.Autocomplete.init(document.querySelector('.autocomplete'), {
    isMultiSelect: true,
    data: [
        {id: 1, text: "Item 1"},
        {id: 2, text: "Item 2"},
        {id: 3, text: "Item 3"}
    ],
    selected: [1, 2]
});
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
