### PR TITLE
feature(Autocomplete) select options

### DIFF
--- a/spec/tests/autocomplete/autocompleteSpec.js
+++ b/spec/tests/autocomplete/autocompleteSpec.js
@@ -263,9 +263,10 @@ describe('Autocomplete Plugin', () => {
         done();
       }, 10);
     });
+
     it('setOptions should select multiple options', (done) => {
       const normal = document.querySelector('#normal-autocomplete');
-      const autocompleteInstance = resetAutocomplete(normal, [
+      resetAutocomplete(normal, [
         { id: 1, text: 'Value A' },
         { id: 2, text: 'Value B' },
         { id: 3, text: 'Value C' }

--- a/spec/tests/autocomplete/autocompleteSpec.js
+++ b/spec/tests/autocomplete/autocompleteSpec.js
@@ -263,5 +263,22 @@ describe('Autocomplete Plugin', () => {
         done();
       }, 10);
     });
+    it('setOptions should select multiple options', (done) => {
+      const normal = document.querySelector('#normal-autocomplete');
+      const autocompleteInstance = resetAutocomplete(normal, [
+        { id: 1, text: 'Value A' },
+        { id: 2, text: 'Value B' },
+        { id: 3, text: 'Value C' }
+      ]);
+      const selectOptions = [2, 3];
+      const autocomplete = M.Autocomplete.getInstance(normal)
+      autocomplete.selectOptions(selectOptions);
+      setTimeout(() => {
+        expect(autocomplete.selectedValues.filter((value) => !(selectOptions.indexOf(value.id) === -1)).length === selectOptions.length)
+          .withContext('filtered selectValues based on selectOptions should match')
+          .toBe(true);
+        done();
+      }, 10)
+    });
   });
 });

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -524,6 +524,7 @@ export class Autocomplete extends Component<AutocompleteOptions> {
 
   /**
    * Sets selected values.
+   * @deprecated @see https://github.com/materializecss/materialize/issues/552
    * @param entries
    */
   setValues(entries: AutocompleteData[]) {
@@ -563,5 +564,14 @@ export class Autocomplete extends Component<AutocompleteOptions> {
     }
     this._updateSelectedInfo();
     this._triggerChanged();
+  }
+
+  selectOptions(ids: []) {
+    const entries = this.menuItems.filter(
+      (item) => !(ids.indexOf(<never>item.id) === -1)
+    );
+    if (!entries) return;
+    this.selectedValues = entries;
+    this._renderDropdown();
   }
 }


### PR DESCRIPTION
## Proposed changes
This pull request fixes #552 and allows multiple selection by method call

Example:
```
M.Autocomplete.init(document.querySelectorAll('.autocomplete'), {
    isMultiSelect: true,
    data: [
        { id: 'Value A' },
        { id: 'Value B' },
        { id: 'Value C' }
    ],
});
M.Autocomplete.getInstance(document.querySelector('.autocomplete')).selectOptions(['Value A']);
```

Additionally I put setValues in deprecated state as it causes issues as described in #552, it still can be used but I would recommend switching to setOption and setOptions methods for selecting values as it would be better to remove the method in one of the next releases, except if someone has another opinion, please shoot

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
