### PR TITLE
fix(Cards) activator styling fix

### DIFF
--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -141,6 +141,10 @@
       bottom: 0;
       cursor: pointer;
     }
+
+    img.activator {
+      position: relative;
+    }
   }
 
   .card-content {

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -134,11 +134,6 @@
     }
 
     .activator {
-      position: absolute;
-      left: 0;
-      right: 0;
-      top:0;
-      bottom: 0;
       cursor: pointer;
     }
   }

--- a/sass/components/_cards.scss
+++ b/sass/components/_cards.scss
@@ -134,6 +134,11 @@
     }
 
     .activator {
+      position: absolute;
+      left: 0;
+      right: 0;
+      top:0;
+      bottom: 0;
       cursor: pointer;
     }
   }


### PR DESCRIPTION
## Proposed changes
This fixes a backwards compatibility issue where activator is set directly on the image, after #555 the card content renders empty if using activator on image instead of div

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
