### PR TITLE
fix(Select) tabIndex values are destroyed during initialization

### DIFF
--- a/js/select.js
+++ b/js/select.js
@@ -34,6 +34,7 @@
       this.options = $.extend({}, FormSelect.defaults, options);
 
       this.isMultiple = this.$el.prop('multiple');
+      this.nativeTabIndex = this.el.tabIndex;
 
       // Setup
       this.el.tabIndex = -1;
@@ -228,6 +229,7 @@
       if (this.el.disabled) {
         $(this.input).prop('disabled', 'true');
       }
+      this.input.setAttribute('tabindex', this.nativeTabIndex);
 
       $(this.wrapper).prepend(this.input);
       this._setValueToInput();


### PR DESCRIPTION
## Proposed changes
This fixes the issue #510 where tabIndex values set on the native select element are lost during the initialization of FormSelect instance.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
