### PR TITLE
Fix dropdown in modal

### DIFF
--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -41,7 +41,6 @@
   }
   .modal-content {
     padding: 0 var(--modal-padding);
-    //overflow-y: auto; // causes select dropdown fail
   }
   .modal-footer {
     border-radius: 0 0 var(--modal-border-radius) var(--modal-border-radius);

--- a/sass/components/_modal.scss
+++ b/sass/components/_modal.scss
@@ -4,6 +4,7 @@
   --modal-border-radius: 28px;
   --modal-padding: 24px;
   --modal-padding-bottom: 16px;
+  --modal-background-color: color-mix(in srgb, var(--md-sys-color-surface), var(--md-sys-color-surface-tint) 17%);
 
   @extend .z-depth-5;
   border: none;
@@ -13,7 +14,7 @@
   width: 55%;
   border-radius: var(--modal-border-radius);
   will-change: top, opacity;
-  background-color: color-mix(in srgb, var(--md-sys-color-surface), var(--md-sys-color-surface-tint) 17%);
+  background-color: var(--modal-background-color);
 
   // Dialog open
   &[open] {
@@ -34,16 +35,22 @@
     padding: var(--modal-padding);
     padding-bottom: var(--modal-padding-bottom);
     flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    background-color: var(--modal-background-color);
   }
   .modal-content {
     padding: 0 var(--modal-padding);
-    overflow-y: auto;
+    //overflow-y: auto; // causes select dropdown fail
   }
   .modal-footer {
     border-radius: 0 0 var(--modal-border-radius) var(--modal-border-radius);
     padding: var(--modal-padding);
     text-align: right;
     flex-shrink: 0;
+    position: sticky;
+    bottom: 0;
+    background-color: var(--modal-background-color);
   }
 
   .modal-close {

--- a/src/select.ts
+++ b/src/select.ts
@@ -57,7 +57,7 @@ export class FormSelect extends Component<FormSelectOptions> {
     };
 
     this.isMultiple = this.el.multiple;
-    this.nativeTabIndex = (this.el.tabIndex ?? -1);
+    this.nativeTabIndex = this.el.tabIndex ?? -1;
     this.el.tabIndex = -1;
     this._values = [];
     this._setupDropdown();
@@ -204,6 +204,7 @@ export class FormSelect extends Component<FormSelectOptions> {
     // Create dropdown
     this.dropdownOptions = document.createElement('ul');
     this.dropdownOptions.id = `select-options-${Utils.guid()}`;
+    this.dropdownOptions.setAttribute('popover', 'auto');
     this.dropdownOptions.classList.add('dropdown-content', 'select-dropdown');
     this.dropdownOptions.setAttribute('role', 'listbox');
     this.dropdownOptions.ariaMultiSelectable = this.isMultiple.toString();


### PR DESCRIPTION
## Proposed changes

This should fix #35. Not an ideal solution but a lot better than before. The modal has overflow enabled, so the dropdown element can not expand properly. Remove the overflowing and make header and footer stick to top and bottom.

## Screenshots (if appropriate) or codepen:

Before:
<img width="717" alt="Screenshot 2025-02-24 at 09 59 37" src="https://github.com/user-attachments/assets/594cdde9-28e6-4df7-bd2a-5b1ffb7e3a39" />

## Types of changes

After:
<img width="712" alt="Screenshot 2025-02-24 at 09 57 09" src="https://github.com/user-attachments/assets/f5be80f0-60e3-407c-96d4-3c364e4f8fc7" />

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
