### PR TITLE
fix(mixins): border none is missing from new button mixin

### DIFF
--- a/sass/components/mixins.module.scss
+++ b/sass/components/mixins.module.scss
@@ -17,6 +17,7 @@
   text-decoration: none;
   display: inline-flex;
   align-items: center;
+  border: none;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent; // Gets rid of tap active state
   white-space: nowrap;


### PR DESCRIPTION
## Proposed changes
A text button with either `btn text` or `btn-flat` has a border. During the move to mixins a `border: none` got lost.

## Screenshots (if appropriate) or codepen:
![image](https://github.com/user-attachments/assets/bd34fd99-216d-4b86-9be6-c723c35521ed)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
