### PR TITLE
fix(_navbar): use .nav instead of nav 

### DIFF
--- a/sass/components/_navbar.scss
+++ b/sass/components/_navbar.scss
@@ -219,7 +219,7 @@
 }
 
 @media #{$medium-and-up} {
-  nav.nav-extended .nav-wrapper {
+  .nav.nav-extended .nav-wrapper {
     min-height: var(--navbar-height-mobile);
   }
   .nav, .navbar .nav-wrapper i, nav a.sidenav-trigger, .navbar a.sidenav-trigger i {


### PR DESCRIPTION
## Proposed changes
The use of `.nav` for navbar is inconsistent. If we use `.nav`, we should use it consistent.

## Screenshots (if appropriate) or codepen:
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
