### PR TITLE
fix(_input-fields): display inline inputs fields actually inline

### DIFF
--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -237,6 +237,11 @@ textarea.materialize-textarea {
   }
 }
 
+/* Inline */
+&.inline {
+  display: inline-block;
+}
+
 /* Search Field */
 .searchbar {
   .prefix {

--- a/sass/components/forms/_input-fields.scss
+++ b/sass/components/forms/_input-fields.scss
@@ -238,7 +238,7 @@ textarea.materialize-textarea {
 }
 
 /* Inline */
-&.inline {
+.inline {
   display: inline-block;
 }
 


### PR DESCRIPTION
## Proposed changes
Includes nested .inline class for .input-fields class elements.

Closes #606 

## Screenshots (if appropriate) or codepen:
![image](https://github.com/user-attachments/assets/02de3116-4468-4d2d-be4e-19c008b9c860)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
