### PR TITLE
fix(_range): display bar for range in chrome browser

### DIFF
--- a/sass/components/forms/_range.scss
+++ b/sass/components/forms/_range.scss
@@ -13,12 +13,13 @@ input[type=range] + .thumb {
 
 input[type=range] {
   position: relative;
-  background-color: transparent;
+  background: linear-gradient(var(--md-sys-color-outline-variant), var(--md-sys-color-outline-variant));
   border: none;
   outline: none;
   width: 100%;
   margin: 15px 0;
   padding: 0;
+  height: 3px;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
## Proposed changes
Fixes not displaying range bar in Chrome browser.

Closes #609 

## Screenshots (if appropriate) or codepen:
![image](https://github.com/user-attachments/assets/184fd108-8086-455a-b7d5-d7456b9be77b)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
