### PR TITLE
fix(_radio-buttons): gray out when disabled

### DIFF
--- a/sass/components/forms/_radio-buttons.scss
+++ b/sass/components/forms/_radio-buttons.scss
@@ -83,30 +83,30 @@
 
 /* Disabled Radio With gap */
 [type="radio"].with-gap:disabled:checked + span:before {
-  border: 2px solid var(--md-sys-color-on-surface);
+  border: 2px solid color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }
 
 [type="radio"].with-gap:disabled:checked + span:after {
   border: none;
-  background-color: var(--md-sys-color-on-surface);
+  background-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }
 
 /* Disabled style */
 [type="radio"]:disabled:not(:checked) + span:before,
 [type="radio"]:disabled:checked + span:before {
   background-color: transparent;
-  border-color: var(--md-sys-color-on-surface);
+  border-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }
 
 [type="radio"]:disabled + span {
-  color: var(--md-sys-color-on-surface);
+  color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }
 
 [type="radio"]:disabled:not(:checked) + span:before {
-  border-color: var(--md-sys-color-on-surface);
+  border-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }
 
 [type="radio"]:disabled:checked + span:after {
-  background-color: var(--md-sys-color-on-surface);
-  border-color: var(--md-sys-color-on-surface);
+  background-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
+  border-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
 }


### PR DESCRIPTION
## Proposed changes
Gray out disabled radio button as defined in [Material 3](https://m3.material.io/components/radio-button/specs)

## Screenshots (if appropriate) or codepen:
<img width="96" alt="image" src="https://github.com/user-attachments/assets/98e50fbd-48fd-4eb9-ab70-a6968464d382" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
