### PR TITLE
fix(_checkboxes): gray out when disabled

### DIFF
--- a/sass/components/forms/_checkboxes.scss
+++ b/sass/components/forms/_checkboxes.scss
@@ -44,8 +44,11 @@
   }
 
   &:not(:checked):disabled + span:not(.lever):before {
-    border: none;
-    background-color: var(--md-sys-color-on-surface);
+    border-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
+  }
+
+  &:disabled + span:not(.lever) {
+    color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
   }
 
   // Focused styles
@@ -74,8 +77,8 @@
   }
 
   &:disabled + span:before {
-    border-right: 2px solid var(--md-sys-color-on-surface);
-    border-bottom: 2px solid var(--md-sys-color-on-surface);
+    border-right: 2px solid color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
+    border-bottom: 2px solid color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
   }
 }
 
@@ -97,7 +100,7 @@
 
   // Disabled indeterminate
   &:disabled + span:not(.lever):before {
-    border-right: 2px solid var(--md-sys-color-on-surface);
+    border-right: 2px solid color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
     background-color: transparent;
   }
 }
@@ -184,8 +187,7 @@
   }
 
   &:disabled:not(:checked) + span:not(.lever):after {
-    border-color: transparent;
-    background-color: var(--md-sys-color-on-surface);
+    border-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
   }
 
   &:disabled:checked + span:not(.lever):before {
@@ -193,7 +195,7 @@
   }
 
   &:disabled:checked + span:not(.lever):after {
-    background-color: var(--md-sys-color-on-surface);
-    border-color: var(--md-sys-color-on-surface);
+    background-color: color-mix(in srgb, transparent, var(--md-sys-color-on-surface) 38%);
+    border: none;
   }
 }


### PR DESCRIPTION
## Proposed changes
Gray out disabled checkbox as defined in [Material 3](https://m3.material.io/components/radio-button/specs)

I also update docs to cover all the scenarios as you can see on the screenshot.

## Screenshots (if appropriate) or codepen:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/48f51fc8-4df5-4628-8c74-e7d21b7763c1" />


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [x] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
