### PR TITLE
fix(Pickers/DisplayPlugin) fixes bug where picker is not visible

### DIFF
--- a/components/datepicker/datepicker.ts
+++ b/components/datepicker/datepicker.ts
@@ -387,6 +387,7 @@ export class Datepicker extends Component<DatepickerOptions> {
           this.containerEl,
           this.options.displayPluginOptions
         );
+      if (this.options.openByDefault) this.displayPlugin.show();
     }
   }
 
@@ -542,11 +543,6 @@ export class Datepicker extends Component<DatepickerOptions> {
     } else {
       //this.containerEl.before(this.el);
       const appendTo = !this.endDateEl ? this.el : this.endDateEl;
-      if (!this.options.openByDefault)
-        (this.containerEl as HTMLElement).setAttribute(
-          'style',
-          'display: none; visibility: hidden;'
-        );
       appendTo.parentElement.after(this.containerEl);
     }
   }


### PR DESCRIPTION
## Proposed changes
Fixes bug where picker is not visible when openByDefault is false #625 
- Removed static HTML style attribute
- Invoke DisplayPlugin show method if openByDefault is set to true

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
