### PR TITLE
fix(preloader): Hide component when not active

### DIFF
--- a/components/progress-indicators/_preloader.scss
+++ b/components/progress-indicators/_preloader.scss
@@ -50,6 +50,10 @@
       animation-delay: 1.15s;
     }
   }
+
+  &:not(.active) {
+    visibility: hidden;
+  }
 }
 
 @keyframes indeterminate {
@@ -133,6 +137,10 @@
     /* duration: 360 * ARCTIME / (ARCSTARTROT + (360-ARCSIZE)) */
     -webkit-animation: container-rotate 1568ms linear infinite;
     animation: container-rotate 1568ms linear infinite;
+  }
+
+  &:not(.active) {
+    visibility: hidden;
   }
 }
 


### PR DESCRIPTION
## Proposed changes

This change introduces a CSS rule to hide the preloader component by default. It uses the `:not(.active)` pseudo-selector to ensure the preloader is only visible when the `.active` class is explicitly applied.

This resolves issue #603 by preventing the preloader from being visible on initialization before it is activated.

## Screenshots (if appropriate) or codepen:

N/A, as this is a CSS-only change to manage the component's default state.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.