### PR TITLE
fix(Carousel) Fix onCycleTo not being called when slide changed

### DIFF
--- a/components/carousel/carousel.ts
+++ b/components/carousel/carousel.ts
@@ -482,6 +482,9 @@ export class Carousel extends Component<CarouselOptions> {
       this.el.classList.remove('scrolling');
     }, this.options.duration);
 
+    // Save last center before updating the center for onCycleTo callback
+    const lastCenter = this.center;
+
     // Start actual scroll
     this.offset = typeof x === 'number' ? x : this.offset;
     this.center = Math.floor((this.offset + this.dim / 2) / this.dim);
@@ -496,7 +499,6 @@ export class Carousel extends Component<CarouselOptions> {
       zTranslation: number,
       tweenedOpacity: number,
       centerTweenedOpacity: number;
-    const lastCenter = this.center;
     const numVisibleOffset = 1 / this.options.numVisible;
 
     // delta = this.offset - this.center * this.dim;


### PR DESCRIPTION
## Proposed changes
fixes #639 
This should fix `onCycleTo` function not being called due to `lastCenter != this.center` being always false. This pull request moves the position of `lastCenter` variable to be updated before the `this.center` was updated.

## Screenshots (if appropriate) or codepen:
Previous behavior: [CodePen](https://codepen.io/Jerit3787/pen/dPYQRxG)

Intended behavior: [Preview](https://www.danplace.tech/materialize-fix) / [Code](https://github.com/Jerit3787/materialize-fix)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
