### PR TITLE
fix: expose CSS, Sass and component sub-paths in package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,13 @@
   "main": "dist/js/materialize.js",
   "module": "./dist/js/materialize.mjs",
   "exports": {
-    "import": "./dist/js/materialize.mjs",
-    "require": "./dist/js/materialize.cjs.js"
+    ".": {
+      "import": "./dist/js/materialize.mjs",
+      "require": "./dist/js/materialize.cjs.js"
+    },
+    "./dist/css/*": "./dist/css/*",
+    "./sass/*": "./sass/*",
+    "./components/*": "./components/*"
   },
   "repository": {
     "type": "git",
@@ -89,6 +94,7 @@
     "dist/css",
     "dist/js",
     "sass/**/*.scss",
+    "components",
     "LICENSE"
   ],
   "overrides": {


### PR DESCRIPTION
Closes #653

## What

Adds wildcard export patterns for CSS, Sass and component sub-paths to the `exports` field, and adds `components/` to the `files` array so component sub-paths are included in the published package.

```json
"exports": {
  ".": {
    "import": "./dist/js/materialize.mjs",
    "require": "./dist/js/materialize.cjs.js"
  },
  "./dist/css/*": "./dist/css/*",
  "./sass/*": "./sass/*",
  "./components/*": "./components/*"
}
```

This enables the following imports in spec-compliant bundlers (esbuild, Vite, webpack 5, Rollup):

```js
import '@materializecss/materialize/dist/css/materialize.min.css';
import '@materializecss/materialize/sass/materialize.scss';
import { Button } from '@materializecss/materialize/components/buttons/button.mjs';
```

## Why

As described in #653, adding an `exports` field without CSS/Sass entries locks down the entire package in spec-compliant bundlers. The top-level `"style"` and `"sass"` fields are shadowed by `exports` and provide no relief in these bundlers.

## Testing

This is a metadata-only change. No distributed files are modified. The existing default import `@materializecss/materialize` continues to work identically via the `"."` entry.