### PR TITLE
Fixes offsets for s1 and s2

### DIFF
--- a/sass/_grid.scss
+++ b/sass/_grid.scss
@@ -65,8 +65,8 @@ body {
   .s11 { grid-column: auto / span 11; }
   .s12 { grid-column: auto / span 12; }
 
-  .offset-s1 { grid-column-start:  3; }
-  .offset-s2 { grid-column-start:  2; }
+  .offset-s1 { grid-column-start:  2; }
+  .offset-s2 { grid-column-start:  3; }
   .offset-s3 { grid-column-start:  4; }
   .offset-s4 { grid-column-start:  5; }
   .offset-s5 { grid-column-start:  6; }


### PR DESCRIPTION
Offsets for 's' were not consistent with 'l' and 'm' causing unexpected behavior.

Fixes: #657 

## Proposed changes
Changes grid column start for s1 and s2 to make it consistent with m1, m2 and l1, l2

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [X] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
