### PR TITLE
chore: add typecheck script and enable strict type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "jasmine-browser-runner runSpecs --config=jasmine.json",
     "build": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "release": "npm run lint && npm run build -- --environment BUILD:release && node compress.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    //"skipLibCheck": true,
+    "strict": true,
+    "skipLibCheck": true,
     //"esModuleInterop": true,
     //"resolveJsonModule": true,
     //"sourceMap": true,
@@ -17,6 +18,8 @@
   "include": [
     "src",
     "src/**/*",
+    "components",
+    "components/**/*",
     "rollup.config.ts"
   ]
 }


### PR DESCRIPTION
## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
The project had no type-checking step. ESLint is configured with `typescript-eslint`'s *recommended* ruleset, which only runs syntactic lint rules; it performs **no type-checking** and there was no `tsc` invocation anywhere in the npm scripts. As a result, type errors were never caught by `npm run lint`, CI, or any other command.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
It is an adjustment to the build/development process, not a modification to the production code.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the **[CONTRIBUTING document](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md)**.
- [ x] My commit messages follows the [conventional commit format](https://github.com/materializecss/materialize/blob/main/CONTRIBUTING.md#submitting-your-pull-request)
- [ ] My change requires a change to the documentation, and updated it accordingly.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
